### PR TITLE
Add `new-terraform-provider` skill

### DIFF
--- a/plugins/terraform-provider-development/skills/new-terraform-provider/SKILL.md
+++ b/plugins/terraform-provider-development/skills/new-terraform-provider/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: new-terraform-provider
+description: Use this when scaffolding a new Terraform provider.
+---
+
+To scaffold a new Terraform provider with Plugin Framework:
+
+1. If I am already in a Terraform provider workspace, then confirm that I want
+   to create a new workspace. If I do not want to create a new workspace, then
+   skip all remaining steps.
+1. Create a new workspace root directory. The root directory name should be
+   prefixed with "terraform-provider-". Perform all subsequent steps in this
+   new workspace.
+1. Initialize a new Go module..
+1. Run `go get -u github.com/hashicorp/terraform-plugin-framework@latest`.
+1. Write a main.go file that follows [the example](assets/main.go).
+1. Remove TODO comments from `main.go`
+1. Run `go mod tidy`
+1. Run `go build -o /dev/null`
+1. Run `go test ./...`
+

--- a/plugins/terraform-provider-development/skills/new-terraform-provider/SKILL.md
+++ b/plugins/terraform-provider-development/skills/new-terraform-provider/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: new-terraform-provider
 description: Use this when scaffolding a new Terraform provider.
+license: MPL-2.0
+metadata:
+  copyright: Copyright IBM Corp. 2026
+  version: "0.0.1"
 ---
 
 To scaffold a new Terraform provider with Plugin Framework:

--- a/plugins/terraform-provider-development/skills/new-terraform-provider/assets/main.go
+++ b/plugins/terraform-provider-development/skills/new-terraform-provider/assets/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"example.org/terraform-provider-demo/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+)
+
+var (
+	// these will be set by the goreleaser configuration
+	// to appropriate values for the compiled binary.
+	version string = "dev"
+
+	// goreleaser can pass other information to the main package, such as the specific commit
+	// https://goreleaser.com/cookbooks/using-main.version/
+)
+
+func main() {
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := providerserver.ServeOpts{
+		// TODO: Update this string with the published name of your provider.
+		// Also update the tfplugindocs generate command to either remove the
+		// -provider-name flag or set its value to the updated provider name.
+		Address: "registry.terraform.io/example/demo",
+		Debug:   debug,
+	}
+
+	err := providerserver.Serve(context.Background(), provider.New(version), opts)
+
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+}


### PR DESCRIPTION
A suggestion.

Build from scratch and get something minimal + understandable without
multi-file find/replace.

I've intentionally avoided the scaffolding repo to experiment with a
skill-only approach. There are nice things in the scaffold that we will
want to borrow, e.g. Actions workflows, linter configuration, and
GoReleaser defaults.
