### PR TITLE
docs: update from add-skill to skills add

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Installation scopes (use `--scope` flag):
 
 ### Method 2: Individual Skill Installation
 
-Install individual skills using npx skills:
+Install individual skills using `npx skills add`:
 
 ```bash
 # List all available skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,26 +78,26 @@ Installation scopes (use `--scope` flag):
 
 ### Method 2: Individual Skill Installation
 
-Install individual skills using npx add-skill:
+Install individual skills using npx skills:
 
 ```bash
 # List all available skills
-npx add-skill hashicorp/agent-skills
+npx skills add hashicorp/agent-skills
 
 # Code generation skills
-npx add-skill hashicorp/agent-skills/terraform/code-generation/skills/terraform-style-guide
-npx add-skill hashicorp/agent-skills/terraform/code-generation/skills/terraform-test
-npx add-skill hashicorp/agent-skills/terraform/code-generation/skills/azure-verified-modules
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/terraform-style-guide
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/terraform-test
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/azure-verified-modules
 
 # Module generation skills
-npx add-skill hashicorp/agent-skills/terraform/module-generation/skills/refactor-module
-npx add-skill hashicorp/agent-skills/terraform/module-generation/skills/terraform-stacks
+npx skills add hashicorp/agent-skills/terraform/module-generation/skills/refactor-module
+npx skills add hashicorp/agent-skills/terraform/module-generation/skills/terraform-stacks
 
 # Provider development skills
-npx add-skill hashicorp/agent-skills/terraform/provider-development/skills/new-terraform-provider
-npx add-skill hashicorp/agent-skills/terraform/provider-development/skills/run-acceptance-tests
-npx add-skill hashicorp/agent-skills/terraform/provider-development/skills/provider-actions
-npx add-skill hashicorp/agent-skills/terraform/provider-development/skills/provider-resources
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/new-terraform-provider
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/run-acceptance-tests
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-actions
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-resources
 ```
 
 Skills are installed to `~/.claude/skills/` or project `.claude/skills/` directory.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Install Agent Skills in GitHub Copilot, Claude Code, Opencode, Cursor, and more:
 
 ```bash
 # List all skills
-npx add-skill hashicorp/agent-skills
+npx skills add hashicorp/agent-skills
 
 # Install a specific skill
-npx add-skill hashicorp/agent-skills/terraform/code-generation/skills/terraform-style-guide
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/terraform-style-guide
 ```
 
 ### Claude Code Plugin

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -50,19 +50,19 @@ claude plugin install terraform-provider-development@hashicorp
 
 ```bash
 # Code generation
-npx add-skill hashicorp/agent-skills/terraform/code-generation/skills/terraform-style-guide
-npx add-skill hashicorp/agent-skills/terraform/code-generation/skills/terraform-test
-npx add-skill hashicorp/agent-skills/terraform/code-generation/skills/azure-verified-modules
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/terraform-style-guide
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/terraform-test
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/azure-verified-modules
 
 # Module generation
-npx add-skill hashicorp/agent-skills/terraform/module-generation/skills/refactor-module
-npx add-skill hashicorp/agent-skills/terraform/module-generation/skills/terraform-stacks
+npx skills add hashicorp/agent-skills/terraform/module-generation/skills/refactor-module
+npx skills add hashicorp/agent-skills/terraform/module-generation/skills/terraform-stacks
 
 # Provider development
-npx add-skill hashicorp/agent-skills/terraform/provider-development/skills/new-terraform-provider
-npx add-skill hashicorp/agent-skills/terraform/provider-development/skills/run-acceptance-tests
-npx add-skill hashicorp/agent-skills/terraform/provider-development/skills/provider-actions
-npx add-skill hashicorp/agent-skills/terraform/provider-development/skills/provider-resources
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/new-terraform-provider
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/run-acceptance-tests
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-actions
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-resources
 ```
 
 ## MCP Server


### PR DESCRIPTION
# Description

Updated the docs to reflect the `skills add` replacement for adding a skill.

```
DEPRECATED: 'add-skill' has been renamed to 'skills'

  Please use: npx skills add <package>

  Example: npx skills add vercel-labs/agent-skills

Run npx skills --help for usage

```