### PR TITLE
Add product template system for new contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to HashiCorp Agent Skills
+
+Thank you for your interest in contributing to the HashiCorp Agent Skills repository!
+
+## Quick Links
+
+- **Adding Products, Plugins, or Skills**: See [examples/README.md](examples/README.md) for detailed instructions
+- **Template Files**: See [examples/new-product-template/](examples/new-product-template/)
+- **Specification**: See [examples/spec.md](examples/spec.md)
+
+## Getting Started
+
+### Prerequisites
+
+- Git
+- Claude Code (for testing skills)
+- Bash (for validation scripts)
+- jq (for JSON validation)
+
+### Clone the Repository
+
+```bash
+git clone https://github.com/hashicorp/agent-skills.git
+cd agent-skills
+```
+
+### Validate Your Environment
+
+```bash
+./scripts/validate-structure.sh
+```
+
+## Types of Contributions
+
+### Adding a New Product
+
+Use the `/new-product` command or follow the manual steps in [examples/README.md](examples/README.md).
+
+Products are top-level directories containing plugins. Examples: `terraform/`, `packer/`
+
+### Adding a Plugin
+
+Plugins are use-case groupings within a product. Each plugin has its own `plugin.json` and contains skills.
+
+### Adding a Skill
+
+Skills are individual SKILL.md files that teach Claude about specific topics or tasks.
+
+### Improving Existing Skills
+
+- Fix errors or outdated information
+- Add missing examples
+- Improve clarity
+
+### Documentation
+
+- Fix typos
+- Improve explanations
+- Add missing sections
+
+## Development Workflow
+
+### 1. Create a Branch
+
+```bash
+git checkout -b add-vault-skills
+```
+
+### 2. Make Changes
+
+Follow the structure documented in [examples/README.md](examples/README.md).
+
+### 3. Validate
+
+```bash
+./scripts/validate-structure.sh
+```
+
+### 4. Test Your Skills
+
+Open Claude Code in the repository and test that your skills work as expected.
+
+### 5. Submit a Pull Request
+
+- Provide a clear description of what you're adding
+- Reference any related issues
+- Ensure CI checks pass
+
+## Code of Conduct
+
+- Be respectful and constructive
+- Follow HashiCorp's community guidelines
+- Help others learn and contribute
+
+## Style Guidelines
+
+### SKILL.md
+
+- Use clear, concise language
+- Include practical examples
+- Link to official documentation
+- Follow the existing skill patterns
+
+### plugin.json
+
+- Use lowercase, hyphenated names
+- Provide descriptive keywords
+- Include accurate descriptions
+
+### Directory Names
+
+- Use lowercase
+- Use hyphens for multi-word names
+- Match the skill/plugin name
+
+## License
+
+All contributions are licensed under MPL-2.0. By submitting a pull request, you agree to license your contribution under this license.
+
+## Questions?
+
+Open an issue if you have questions about contributing.

--- a/examples/.claude-plugin/plugin.json
+++ b/examples/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "agent-skills-templates",
+  "version": "1.0.0",
+  "description": "Templates and commands for adding new HashiCorp products to agent-skills",
+  "author": {
+    "name": "HashiCorp",
+    "url": "https://github.com/hashicorp"
+  },
+  "homepage": "https://github.com/hashicorp/agent-skills",
+  "repository": "https://github.com/hashicorp/agent-skills",
+  "license": "MPL-2.0",
+  "keywords": ["templates", "scaffolding", "generator", "hashicorp"]
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,357 @@
+# Agent Skills Templates
+
+This directory contains templates, documentation, and automation for adding new HashiCorp products to the agent-skills repository.
+
+## Quick Start
+
+### Using the Slash Command
+
+The fastest way to add a new product:
+
+```
+/new-product vault
+```
+
+This interactive command walks you through creating a complete product structure with plugins and skills.
+
+### Manual Creation
+
+Follow the step-by-step guide below to create products manually.
+
+---
+
+## Repository Structure
+
+```
+agent-skills/
+├── .claude-plugin/
+│   └── marketplace.json       # Plugin registry (update when adding products)
+├── terraform/                  # Example: Terraform product
+│   ├── README.md
+│   ├── code-generation/        # Plugin: terraform-code-generation
+│   │   ├── .claude-plugin/
+│   │   │   └── plugin.json
+│   │   └── skills/
+│   │       ├── terraform-style-guide/
+│   │       │   └── SKILL.md
+│   │       └── terraform-test/
+│   │           └── SKILL.md
+│   └── provider-development/   # Plugin: terraform-provider-development
+│       └── ...
+├── packer/                     # Example: Packer product
+│   └── ...
+├── examples/                   # Templates and documentation (this directory)
+│   ├── README.md               # This file
+│   ├── spec.md                 # Specification document
+│   ├── questionnaire.md        # Questions for automation
+│   ├── new-product-template/   # Template files
+│   └── commands/
+│       └── new-product/        # Slash command
+└── scripts/
+    └── validate-structure.sh   # Validation script
+```
+
+---
+
+## Adding a New Product
+
+### Step 1: Create Product Directory
+
+```bash
+mkdir -p vault/secrets-management/.claude-plugin
+mkdir -p vault/secrets-management/skills/kv-secrets-engine
+```
+
+### Step 2: Create Product README.md
+
+Create `vault/README.md`:
+
+```markdown
+# HashiCorp Vault Skills
+
+Agent skills for identity-based secrets and encryption management.
+
+## Plugins
+
+### vault-secrets-management
+
+Skills for storing and managing secrets in Vault.
+
+| Skill | Description |
+|-------|-------------|
+| `kv-secrets-engine` | Store and retrieve static secrets with KV v2 |
+
+## Installation
+
+### Claude Code Plugin
+
+\`\`\`bash
+claude plugin marketplace add hashicorp/agent-skills
+claude plugin install vault-secrets-management@hashicorp
+\`\`\`
+
+## References
+
+- [Vault Documentation](https://developer.hashicorp.com/vault)
+```
+
+### Step 3: Create plugin.json
+
+Create `vault/secrets-management/.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "vault-secrets-management",
+  "version": "1.0.0",
+  "description": "Vault secrets management skills for storing and retrieving secrets.",
+  "author": {
+    "name": "HashiCorp",
+    "url": "https://github.com/hashicorp"
+  },
+  "homepage": "https://developer.hashicorp.com/vault",
+  "repository": "https://github.com/hashicorp/agent-skills",
+  "license": "MPL-2.0",
+  "keywords": ["vault", "secrets", "kv", "hashicorp"]
+}
+```
+
+### Step 4: Create SKILL.md
+
+Create `vault/secrets-management/skills/kv-secrets-engine/SKILL.md`:
+
+```markdown
+---
+name: kv-secrets-engine
+description: Store and retrieve static secrets using Vault's KV v2 secrets engine. Use when working with key-value secrets, versioning, or secret metadata.
+---
+
+# KV Secrets Engine
+
+Store and manage static secrets with versioning support.
+
+**Reference:** [KV Secrets Engine](https://developer.hashicorp.com/vault/docs/secrets/kv)
+
+## Basic Usage
+
+\`\`\`bash
+# Write a secret
+vault kv put secret/myapp username=admin password=secret
+
+# Read a secret
+vault kv get secret/myapp
+
+# List secrets
+vault kv list secret/
+\`\`\`
+
+## References
+
+- [KV v2 Documentation](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2)
+```
+
+### Step 5: Update marketplace.json
+
+Add your plugins to `.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "vault-secrets-management",
+  "source": "./vault/secrets-management",
+  "description": "Vault secrets management skills for storing and retrieving secrets.",
+  "version": "1.0.0",
+  "author": {
+    "name": "HashiCorp"
+  },
+  "keywords": ["vault", "secrets", "kv", "hashicorp"],
+  "category": "integration",
+  "license": "MPL-2.0",
+  "strict": false
+}
+```
+
+### Step 6: Validate
+
+```bash
+./scripts/validate-structure.sh
+```
+
+---
+
+## Adding a Plugin to an Existing Product
+
+1. Create plugin directory: `{product}/{use-case}/`
+2. Create `.claude-plugin/plugin.json`
+3. Create `skills/` subdirectory
+4. Add at least one skill
+5. Update marketplace.json
+6. Update product README.md
+
+---
+
+## Adding a Skill to an Existing Plugin
+
+1. Create skill directory: `{product}/{use-case}/skills/{skill-name}/`
+2. Create `SKILL.md` with frontmatter
+3. Update plugin's skill table in product README.md
+
+---
+
+## SKILL.md Frontmatter Reference
+
+### Required Fields
+
+```yaml
+---
+name: skill-name
+description: When to use this skill. Claude uses this to decide when to apply it.
+---
+```
+
+### Optional Fields
+
+```yaml
+---
+name: skill-name
+description: Skill description
+disable-model-invocation: true    # Only user can invoke (for task skills)
+user-invocable: false             # Only Claude can invoke (for background knowledge)
+allowed-tools: Read, Grep, Bash(vault *)  # Tool restrictions
+context: fork                     # Run in subagent
+agent: Explore                    # Subagent type (with context: fork)
+argument-hint: "[secret-path]"    # Autocomplete hint
+---
+```
+
+### Custom Fields (HashiCorp)
+
+These fields are not part of the official spec but are used in this repository:
+
+```yaml
+metadata:
+  copyright: Copyright HashiCorp 2026
+  version: "1.0.0"
+license: MPL-2.0
+```
+
+---
+
+## plugin.json Reference
+
+### Required Fields
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `name` | Plugin identifier | `vault-secrets-management` |
+| `version` | Semantic version | `1.0.0` |
+| `description` | What the plugin provides | `Skills for managing Vault secrets` |
+| `author.name` | Author name | `HashiCorp` |
+| `homepage` | Documentation URL | `https://developer.hashicorp.com/vault` |
+| `repository` | Source repository | `https://github.com/hashicorp/agent-skills` |
+| `license` | License identifier | `MPL-2.0` |
+| `keywords` | Discoverability tags | `["vault", "secrets"]` |
+
+### Optional Fields
+
+| Field | Description |
+|-------|-------------|
+| `author.url` | Author URL |
+| `mcpServers` | MCP server configuration |
+
+### MCP Server Configuration
+
+```json
+{
+  "mcpServers": {
+    "vault": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "hashicorp/vault-mcp-server"],
+      "env": {
+        "VAULT_ADDR": "${VAULT_ADDR}",
+        "VAULT_TOKEN": "${VAULT_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Skill Types
+
+### Reference Skills
+
+Provide knowledge Claude applies to your work. No side effects.
+
+```yaml
+---
+name: terraform-style-guide
+description: Generate Terraform HCL following HashiCorp conventions.
+---
+```
+
+### Task Skills
+
+Perform actions like file creation or command execution. Add `disable-model-invocation: true` to prevent Claude from triggering automatically.
+
+```yaml
+---
+name: new-terraform-provider
+description: Scaffold a new Terraform provider project.
+disable-model-invocation: true
+---
+```
+
+---
+
+## Supporting Files
+
+Skills can include additional files:
+
+```
+my-skill/
+├── SKILL.md           # Main instructions (required)
+├── assets/            # Code templates, examples
+│   └── main.go
+├── references/        # Detailed documentation
+│   └── api-reference.md
+└── examples/          # Usage examples
+    └── basic-usage.md
+```
+
+Reference these from SKILL.md:
+
+```markdown
+See [assets/main.go](assets/main.go) for the template.
+```
+
+---
+
+## Validation
+
+The repository includes validation that runs on every PR:
+
+```bash
+# Run locally before committing
+./scripts/validate-structure.sh
+```
+
+### What's Validated
+
+- marketplace.json is valid JSON with required fields
+- All referenced plugin paths exist
+- All plugins have plugin.json with required fields
+- All plugins have skills/ directory with at least one skill
+- All SKILL.md files have valid frontmatter with name and description
+
+---
+
+## Files in This Directory
+
+| File | Purpose |
+|------|---------|
+| `README.md` | This guide |
+| `spec.md` | Spec-Kit format specification with user stories |
+| `questionnaire.md` | All questions needed for product creation |
+| `new-product-template/` | Template files with placeholders |
+| `commands/new-product/` | Slash command implementation |
+| `.claude-plugin/plugin.json` | Plugin definition for templates |

--- a/examples/commands/new-product/COMMAND.md
+++ b/examples/commands/new-product/COMMAND.md
@@ -1,0 +1,208 @@
+---
+name: new-product
+description: Scaffold a new HashiCorp product with plugins and skills in the agent-skills repository. Use when adding a new product like Vault, Consul, Nomad, or Boundary.
+disable-model-invocation: true
+argument-hint: "[product-name]"
+---
+
+# New Product Generator
+
+Generate a complete product structure for the agent-skills repository.
+
+## Prerequisites
+
+- You are in the agent-skills repository root
+- You have write access to create directories and files
+- You know the product details (name, use cases, skills)
+
+## Process
+
+Follow these steps to create a new product. Ask the user for each piece of information.
+
+### Step 1: Gather Product Information
+
+Ask the user:
+
+1. **Product name** (lowercase, no spaces): e.g., `vault`, `consul`, `nomad`
+2. **Display name**: e.g., `HashiCorp Vault`
+3. **Short description**: One sentence describing the product
+4. **Documentation homepage**: URL to developer.hashicorp.com
+
+### Step 2: Define Use Cases (Plugins)
+
+For each plugin the user wants to create, ask:
+
+1. **Use case name** (lowercase, hyphens): e.g., `secrets-management`
+2. **Plugin description**: What skills in this plugin help with
+3. **Keywords**: Tags for discoverability (comma-separated)
+4. **MCP server needed?**: If yes, gather command, args, env vars
+
+Repeat until user says they're done adding plugins.
+
+### Step 3: Define Skills
+
+For each plugin, ask about skills:
+
+1. **Skill name** (lowercase, hyphens): e.g., `kv-secrets-engine`
+2. **Display title**: e.g., `KV Secrets Engine`
+3. **Description**: When Claude should use this skill
+4. **Primary reference URL**: Link to official documentation
+5. **Is this a task skill?**: If yes, add `disable-model-invocation: true`
+
+Repeat until user says they're done adding skills to this plugin.
+
+### Step 4: Generate Structure
+
+Create the following structure:
+
+```
+{product}/
+├── README.md
+├── {use-case-1}/
+│   ├── .claude-plugin/
+│   │   └── plugin.json
+│   └── skills/
+│       ├── {skill-1}/
+│       │   └── SKILL.md
+│       └── {skill-2}/
+│           └── SKILL.md
+└── {use-case-2}/
+    └── ...
+```
+
+#### 4.1 Create Product README.md
+
+```markdown
+# {Display Name} Skills
+
+Agent skills for {short description}.
+
+## Plugins
+
+### {plugin-name}
+
+{plugin description}
+
+| Skill | Description |
+|-------|-------------|
+| `{skill-name}` | {skill description} |
+
+## Installation
+
+### Claude Code Plugin
+
+\`\`\`bash
+claude plugin marketplace add hashicorp/agent-skills
+
+claude plugin install {plugin-name}@hashicorp
+\`\`\`
+
+### Individual Skills
+
+\`\`\`bash
+npx skills add hashicorp/agent-skills/{product}/{use-case}/skills/{skill-name}
+\`\`\`
+
+## References
+
+- [{Display Name} Documentation]({homepage})
+```
+
+#### 4.2 Create plugin.json for Each Plugin
+
+```json
+{
+  "name": "{product}-{use-case}",
+  "version": "1.0.0",
+  "description": "{plugin description}",
+  "author": {
+    "name": "HashiCorp",
+    "url": "https://github.com/hashicorp"
+  },
+  "homepage": "{product homepage}",
+  "repository": "https://github.com/hashicorp/agent-skills",
+  "license": "MPL-2.0",
+  "keywords": [{keywords as JSON array}]
+}
+```
+
+#### 4.3 Create SKILL.md for Each Skill
+
+```markdown
+---
+name: {skill-name}
+description: {skill description}
+---
+
+# {Skill Title}
+
+{Brief introduction based on description}
+
+**Reference:** [{Reference Title}]({reference URL})
+
+## Overview
+
+TODO: Add overview content
+
+## Usage
+
+TODO: Add usage examples
+
+## Common Issues
+
+TODO: Add troubleshooting
+
+## References
+
+- [{Reference Title}]({reference URL})
+```
+
+### Step 5: Update marketplace.json
+
+Add entries for each new plugin to `.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "{product}-{use-case}",
+  "source": "./{product}/{use-case}",
+  "description": "{plugin description}",
+  "version": "1.0.0",
+  "author": {
+    "name": "HashiCorp"
+  },
+  "keywords": [{keywords}],
+  "category": "integration",
+  "license": "MPL-2.0",
+  "strict": false
+}
+```
+
+### Step 6: Validate
+
+Run validation to ensure structure is correct:
+
+```bash
+./scripts/validate-structure.sh
+```
+
+Fix any errors before committing.
+
+### Step 7: Update Documentation
+
+1. Add product to root README.md product table
+2. Update CHANGELOG.md with new plugins and skills
+
+## Output Summary
+
+After completion, report:
+
+- Number of plugins created
+- Number of skills created
+- Files created (list)
+- Validation status
+- Next steps (fill in TODO sections, run tests)
+
+## Reference
+
+See [examples/questionnaire.md](../questionnaire.md) for the complete list of questions.
+See [examples/spec.md](../spec.md) for acceptance criteria.

--- a/examples/new-product-template/{product}/README.md.template
+++ b/examples/new-product-template/{product}/README.md.template
@@ -1,0 +1,63 @@
+# {{PRODUCT_DISPLAY_NAME}} Skills
+
+Agent skills for {{PRODUCT_DESCRIPTION_SHORT}}.
+
+## Plugins
+
+{{#PLUGINS}}
+### {{PLUGIN_NAME}}
+
+{{PLUGIN_DESCRIPTION}}
+
+| Skill | Description |
+|-------|-------------|
+{{#SKILLS}}
+| `{{SKILL_NAME}}` | {{SKILL_DESCRIPTION_SHORT}} |
+{{/SKILLS}}
+
+{{/PLUGINS}}
+
+## Installation
+
+### Claude Code Plugin
+
+```bash
+claude plugin marketplace add hashicorp/agent-skills
+
+{{#PLUGINS}}
+claude plugin install {{PLUGIN_NAME}}@hashicorp
+{{/PLUGINS}}
+```
+
+### Individual Skills
+
+```bash
+{{#PLUGINS}}
+# {{PLUGIN_DISPLAY_NAME}}
+{{#SKILLS}}
+npx skills add hashicorp/agent-skills/{{PRODUCT_NAME}}/{{USE_CASE}}/skills/{{SKILL_NAME}}
+{{/SKILLS}}
+
+{{/PLUGINS}}
+```
+
+## Structure
+
+```
+{{PRODUCT_NAME}}/
+{{#PLUGINS}}
+├── {{USE_CASE}}/
+│   ├── .claude-plugin/plugin.json
+│   └── skills/
+{{#SKILLS}}
+│       └── {{SKILL_NAME}}/
+{{/SKILLS}}
+{{/PLUGINS}}
+└── README.md
+```
+
+## References
+
+{{#REFERENCES}}
+- [{{REFERENCE_TITLE}}]({{REFERENCE_URL}})
+{{/REFERENCES}}

--- a/examples/new-product-template/{product}/{use-case}/.claude-plugin/plugin.json.template
+++ b/examples/new-product-template/{product}/{use-case}/.claude-plugin/plugin.json.template
@@ -1,0 +1,23 @@
+{
+  "name": "{{PLUGIN_NAME}}",
+  "version": "1.0.0",
+  "description": "{{PLUGIN_DESCRIPTION}}",
+  "author": {
+    "name": "HashiCorp",
+    "url": "https://github.com/hashicorp"
+  },
+  "homepage": "{{PRODUCT_HOMEPAGE}}",
+  "repository": "https://github.com/hashicorp/agent-skills",
+  "license": "MPL-2.0",
+  "keywords": [{{#KEYWORDS}}"{{KEYWORD}}"{{^LAST}}, {{/LAST}}{{/KEYWORDS}}]{{#MCP_SERVER}},
+  "mcpServers": {
+    "{{MCP_SERVER_NAME}}": {
+      "command": "{{MCP_COMMAND}}",
+      "args": [{{#MCP_ARGS}}"{{ARG}}"{{^LAST}}, {{/LAST}}{{/MCP_ARGS}}],
+      "env": {
+        {{#MCP_ENV}}"{{ENV_KEY}}": "{{ENV_VALUE}}"{{^LAST}},
+        {{/LAST}}{{/MCP_ENV}}
+      }
+    }
+  }{{/MCP_SERVER}}
+}

--- a/examples/new-product-template/{product}/{use-case}/skills/{skill-name}/SKILL.md.template
+++ b/examples/new-product-template/{product}/{use-case}/skills/{skill-name}/SKILL.md.template
@@ -1,0 +1,53 @@
+---
+name: {{SKILL_NAME}}
+description: {{SKILL_DESCRIPTION}}
+{{#DISABLE_MODEL_INVOCATION}}disable-model-invocation: true
+{{/DISABLE_MODEL_INVOCATION}}{{#ALLOWED_TOOLS}}allowed-tools: {{ALLOWED_TOOLS}}
+{{/ALLOWED_TOOLS}}{{#CONTEXT_FORK}}context: fork
+agent: {{AGENT_TYPE}}
+{{/CONTEXT_FORK}}---
+
+# {{SKILL_TITLE}}
+
+{{SKILL_INTRODUCTION}}
+
+**Reference:** [{{REFERENCE_TITLE}}]({{REFERENCE_URL}})
+
+{{#NOTE}}
+> **Note:** {{NOTE_TEXT}}
+{{/NOTE}}
+
+## {{SECTION_1_TITLE}}
+
+{{SECTION_1_CONTENT}}
+
+## {{SECTION_2_TITLE}}
+
+{{SECTION_2_CONTENT}}
+
+{{#ADDITIONAL_SECTIONS}}
+## {{SECTION_TITLE}}
+
+{{SECTION_CONTENT}}
+
+{{/ADDITIONAL_SECTIONS}}
+
+## Common Issues
+
+{{#COMMON_ISSUES}}
+**{{ISSUE_TITLE}}**
+{{ISSUE_SOLUTION}}
+
+{{/COMMON_ISSUES}}
+
+## Best Practices
+
+{{#BEST_PRACTICES}}
+- {{PRACTICE}}
+{{/BEST_PRACTICES}}
+
+## References
+
+{{#REFERENCES}}
+- [{{REFERENCE_TITLE}}]({{REFERENCE_URL}})
+{{/REFERENCES}}

--- a/examples/questionnaire.md
+++ b/examples/questionnaire.md
@@ -1,0 +1,159 @@
+# Product Template Questionnaire
+
+This document lists all questions that must be answered to generate a new product, plugin, or skill using the template system. Use this as a checklist when adding new content.
+
+---
+
+## Adding a New Product
+
+Answer these questions to create a complete product structure.
+
+### Product Metadata
+
+| Question | Field | Example |
+|----------|-------|---------|
+| What is the product identifier? (lowercase, no spaces) | `PRODUCT_NAME` | `vault` |
+| What is the display name? | `PRODUCT_DISPLAY_NAME` | `HashiCorp Vault` |
+| What does this product do? (one sentence) | `PRODUCT_DESCRIPTION_SHORT` | `Identity-based secrets and encryption management` |
+| What is the documentation homepage? | `PRODUCT_HOMEPAGE` | `https://developer.hashicorp.com/vault` |
+
+### Use Cases (Plugins)
+
+For each plugin in the product:
+
+| Question | Field | Example |
+|----------|-------|---------|
+| What use case does this plugin address? | `USE_CASE` | `secrets-management` |
+| What is the full plugin name? | `PLUGIN_NAME` | `vault-secrets-management` |
+| What do the skills in this plugin help with? | `PLUGIN_DESCRIPTION` | `Skills for storing and retrieving secrets in Vault` |
+| What keywords describe this plugin? | `KEYWORDS` | `vault`, `secrets`, `kv`, `dynamic-credentials` |
+| Does this plugin need an MCP server? | `MCP_SERVER` | See MCP section below |
+
+### Skills
+
+For each skill in a plugin:
+
+| Question | Field | Example |
+|----------|-------|---------|
+| What is the skill identifier? (lowercase, hyphens) | `SKILL_NAME` | `kv-secrets-engine` |
+| What is the display title? | `SKILL_TITLE` | `KV Secrets Engine` |
+| When should Claude use this skill? | `SKILL_DESCRIPTION` | `Use when storing static secrets, reading KV paths, or configuring KV v2 versioning` |
+| What is the primary documentation reference? | `REFERENCE_URL` | `https://developer.hashicorp.com/vault/docs/secrets/kv` |
+| Is this a task skill (performs actions)? | `DISABLE_MODEL_INVOCATION` | `true` for tasks, omit for reference |
+| What tools does this skill need? | `ALLOWED_TOOLS` | `Read, Grep, Bash(vault *)` |
+| What are the main sections? | Content outline | See below |
+
+---
+
+## Skill Content Outline
+
+For each skill, outline the main sections:
+
+```markdown
+## Section 1: [Title]
+- What concepts to cover
+- What commands/examples to include
+
+## Section 2: [Title]
+- Configuration examples
+- Code snippets
+
+## Common Issues
+- Issue 1: [Description] → [Solution]
+- Issue 2: [Description] → [Solution]
+
+## Best Practices
+- Practice 1
+- Practice 2
+
+## References
+- [Title](URL)
+```
+
+---
+
+## MCP Server Configuration (Optional)
+
+If the plugin integrates with an MCP server:
+
+| Question | Field | Example |
+|----------|-------|---------|
+| What is the MCP server name? | `MCP_SERVER_NAME` | `vault` |
+| What command runs the server? | `MCP_COMMAND` | `docker` |
+| What arguments does it need? | `MCP_ARGS` | `["run", "-i", "--rm", "hashicorp/vault-mcp-server"]` |
+| What environment variables? | `MCP_ENV` | `VAULT_ADDR`, `VAULT_TOKEN` |
+
+---
+
+## Validation Checklist
+
+Before submitting, verify:
+
+- [ ] Product directory name matches `PRODUCT_NAME`
+- [ ] All plugin directories have `.claude-plugin/plugin.json`
+- [ ] All plugin directories have `skills/` subdirectory
+- [ ] All skills have `SKILL.md` with valid frontmatter
+- [ ] SKILL.md frontmatter includes `name` and `description`
+- [ ] marketplace.json updated with all new plugins
+- [ ] `scripts/validate-structure.sh` passes
+- [ ] Product README.md lists all plugins and skills
+
+---
+
+## Quick Reference: Required vs Optional
+
+### Required Fields
+
+**plugin.json:**
+- `name`
+- `version`
+- `description`
+- `author.name`
+- `homepage`
+- `repository`
+- `license`
+- `keywords`
+
+**SKILL.md frontmatter:**
+- `name`
+- `description`
+
+### Optional Fields
+
+**plugin.json:**
+- `author.url`
+- `mcpServers`
+
+**SKILL.md frontmatter:**
+- `disable-model-invocation`
+- `user-invocable`
+- `allowed-tools`
+- `context`
+- `agent`
+- `argument-hint`
+- `metadata.copyright`
+- `metadata.version`
+
+---
+
+## Example: Vault Secrets Management
+
+```yaml
+# Product
+PRODUCT_NAME: vault
+PRODUCT_DISPLAY_NAME: HashiCorp Vault
+PRODUCT_DESCRIPTION_SHORT: Identity-based secrets and encryption management
+PRODUCT_HOMEPAGE: https://developer.hashicorp.com/vault
+
+# Plugin
+USE_CASE: secrets-management
+PLUGIN_NAME: vault-secrets-management
+PLUGIN_DESCRIPTION: Skills for storing and managing secrets in Vault
+KEYWORDS: [vault, secrets, kv, dynamic-credentials, transit, pki]
+
+# Skill
+SKILL_NAME: kv-secrets-engine
+SKILL_TITLE: KV Secrets Engine
+SKILL_DESCRIPTION: Use when storing static secrets, reading KV paths, managing versions, or configuring KV v2 secret engine.
+REFERENCE_URL: https://developer.hashicorp.com/vault/docs/secrets/kv
+```

--- a/examples/spec.md
+++ b/examples/spec.md
@@ -1,0 +1,178 @@
+# Feature Specification: New Product Template System
+
+**Feature Branch**: `add-product-templates`  
+**Created**: 2026-02-02  
+**Status**: Implementation  
+
+---
+
+## Executive Summary
+
+This specification defines a reusable template system for adding new HashiCorp product agent skills to the agent-skills repository. The system includes template files, a Claude Code slash command for interactive generation, comprehensive documentation, and validation integration.
+
+---
+
+## User Scenarios & Acceptance Criteria
+
+### User Story 1 - Contributor Adds New Product (Priority: P1)
+
+A HashiCorp employee or community contributor wants to add agent skills for a new HashiCorp product (e.g., Vault, Consul, Nomad) to the repository.
+
+**Why this priority**: This is the primary use case - enabling contributors to add products consistently.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contributor runs `/new-product`, **When** they provide product details, **Then** the command generates a complete directory structure matching existing patterns.
+
+2. **Given** generated files exist, **When** `scripts/validate-structure.sh` runs, **Then** all validations pass without errors.
+
+3. **Given** a contributor follows the template, **When** they submit a PR, **Then** CI workflows validate the structure automatically.
+
+---
+
+### User Story 2 - Contributor Adds Plugin to Existing Product (Priority: P1)
+
+A contributor wants to add a new use-case plugin (e.g., `vault-pki`) to an existing product directory.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing product directory, **When** contributor uses templates to add a plugin, **Then** the new plugin integrates with existing structure.
+
+2. **Given** a new plugin is added, **When** marketplace.json is updated, **Then** the plugin is discoverable via `claude plugin install`.
+
+---
+
+### User Story 3 - Contributor Adds Skill to Existing Plugin (Priority: P1)
+
+A contributor wants to add a new skill to an existing plugin.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing plugin, **When** contributor creates a skill directory with SKILL.md, **Then** the skill passes frontmatter validation.
+
+2. **Given** a SKILL.md file, **When** it includes required fields (name, description), **Then** Claude Code loads it correctly.
+
+---
+
+### User Story 4 - Maintainer Reviews Contribution (Priority: P2)
+
+A repository maintainer reviews a PR adding a new product or skills.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR with new product files, **When** CI runs, **Then** structure validation, JSON validation, and SKILL.md validation all pass.
+
+2. **Given** contribution follows template, **When** maintainer reviews, **Then** structure is consistent with Terraform/Packer patterns.
+
+---
+
+## Functional Requirements
+
+### FR-1: Template Files
+
+| Requirement | Description |
+|-------------|-------------|
+| FR-1.1 | Product README.md template with placeholders for product metadata |
+| FR-1.2 | plugin.json template with all required and optional fields |
+| FR-1.3 | SKILL.md template with standard and optional frontmatter |
+| FR-1.4 | Templates use Mustache-style `{{VARIABLE}}` syntax |
+
+### FR-2: Slash Command
+
+| Requirement | Description |
+|-------------|-------------|
+| FR-2.1 | `/new-product` command prompts for product metadata |
+| FR-2.2 | Command prompts for use cases (plugins) iteratively |
+| FR-2.3 | Command prompts for skills per plugin |
+| FR-2.4 | Command generates complete directory structure |
+| FR-2.5 | Command updates marketplace.json with new plugins |
+| FR-2.6 | Command validates generated structure |
+
+### FR-3: Documentation
+
+| Requirement | Description |
+|-------------|-------------|
+| FR-3.1 | examples/README.md explains how to add products, plugins, skills |
+| FR-3.2 | CONTRIBUTING.md provides general contribution guidelines |
+| FR-3.3 | Questionnaire documents all required information |
+| FR-3.4 | Template variable reference explains all placeholders |
+
+### FR-4: Validation Integration
+
+| Requirement | Description |
+|-------------|-------------|
+| FR-4.1 | Generated products pass validate-structure.sh |
+| FR-4.2 | Generated JSON passes jq validation |
+| FR-4.3 | Generated SKILL.md passes frontmatter validation |
+
+---
+
+## Non-Functional Requirements
+
+### NFR-1: Consistency
+
+Generated products must be structurally identical to existing Terraform and Packer products.
+
+### NFR-2: Compatibility
+
+Templates must work with Claude Code's skill and plugin discovery mechanisms.
+
+### NFR-3: Maintainability
+
+Templates should be easy to update when patterns evolve.
+
+### NFR-4: Self-Documentation
+
+Templates should include comments explaining each section.
+
+---
+
+## Template Variables Reference
+
+### Product Level
+
+| Variable | Required | Description | Example |
+|----------|----------|-------------|---------|
+| `PRODUCT_NAME` | Yes | Lowercase identifier | `vault` |
+| `PRODUCT_DISPLAY_NAME` | Yes | Human-readable name | `HashiCorp Vault` |
+| `PRODUCT_DESCRIPTION_SHORT` | Yes | One-line description | `Identity-based secrets management` |
+| `PRODUCT_HOMEPAGE` | Yes | Documentation URL | `https://developer.hashicorp.com/vault` |
+
+### Plugin Level
+
+| Variable | Required | Description | Example |
+|----------|----------|-------------|---------|
+| `PLUGIN_NAME` | Yes | Plugin identifier | `vault-secrets-management` |
+| `USE_CASE` | Yes | Use case directory name | `secrets-management` |
+| `PLUGIN_DESCRIPTION` | Yes | What the plugin provides | `Skills for managing secrets in Vault` |
+| `KEYWORDS` | Yes | Array of tags | `["vault", "secrets", "kv"]` |
+| `MCP_SERVER` | No | MCP server configuration | See template |
+
+### Skill Level
+
+| Variable | Required | Description | Example |
+|----------|----------|-------------|---------|
+| `SKILL_NAME` | Yes | Skill identifier | `kv-secrets-engine` |
+| `SKILL_DESCRIPTION` | Yes | When to use this skill | `Use when storing static secrets...` |
+| `SKILL_TITLE` | Yes | Display title | `KV Secrets Engine` |
+| `REFERENCE_URL` | Yes | Primary documentation link | `https://developer.hashicorp.com/vault/docs/secrets/kv` |
+| `DISABLE_MODEL_INVOCATION` | No | Set true for task skills | `true` |
+| `ALLOWED_TOOLS` | No | Tool restrictions | `Read, Grep, Bash(vault *)` |
+
+---
+
+## Out of Scope
+
+- Automated content generation (templates provide structure, not content)
+- Skill content quality validation (beyond structural checks)
+- Cross-product dependency management
+- Version migration tooling
+
+---
+
+## Success Metrics
+
+1. New products can be added in < 30 minutes using templates
+2. 100% of generated structures pass validation
+3. Zero structural inconsistencies between products
+4. Contributors report templates as "helpful" in PR feedback


### PR DESCRIPTION
## Summary
- Add reusable templates for contributing new products, plugins, and skills
- Follow patterns established by existing Terraform and Packer plugins
- Include discovery questions for agent-assisted automation

## Structure
```
examples/
├── .claude-plugin/plugin.json
├── README.md                           # Comprehensive contributor guide
├── spec.md                             # GitHub Spec-Kit style template
├── questionnaire.md                    # Discovery questions for automation
├── commands/
│   └── new-product/
│       └── COMMAND.md                  # Interactive scaffolding command
└── new-product-template/
    └── {product}/
        ├── README.md.template
        └── {use-case}/
            ├── .claude-plugin/plugin.json.template
            └── skills/
                └── {skill-name}/SKILL.md.template
```

## Changes
- Created `examples/README.md` with step-by-step instructions for adding products, plugins, and skills
- Created `examples/spec.md` GitHub Spec-Kit style specification template
- Created `examples/questionnaire.md` with discovery questions for agent automation
- Created `examples/new-product-template/` with placeholder-based templates
- Created `examples/commands/new-product/` for interactive scaffolding via `/new-product`
- Added `CONTRIBUTING.md` with contribution guidelines and workflow

## Testing
- Templates validated against existing Terraform and Packer plugin structures
- All placeholder patterns (`{product}`, `{use-case}`, `{skill-name}`) documented