### PR TITLE
ci: add Tessl skill review and directory structure validation

### DIFF
--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -1,0 +1,290 @@
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/SKILL.md'
+      - '**/skills/**'
+  workflow_dispatch:
+    inputs:
+      run_evals:
+        description: 'Run task-based evals in addition to skill review'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  TESSL_TOKEN: ${{ secrets.TESSL_API_KEY }}
+
+jobs:
+  review-skills:
+    name: Review Skills
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+
+      - name: Install Tessl CLI
+        run: npm install -g @tessl/cli
+
+      - name: Detect changed skills
+        id: detect
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Check for eval-scenarios changes and warn
+            EVAL_CHANGES=$(git diff --name-only --diff-filter=ACMR \
+              "origin/${{ github.base_ref }}"...HEAD -- '**/eval-scenarios/**' || true)
+            if [[ -n "$EVAL_CHANGES" ]]; then
+              echo "::warning::This PR modifies eval-scenarios/ files. These should only be changed by maintainers."
+            fi
+
+            # Find changed SKILL.md files and extract skill directories
+            CHANGED_SKILLS=$(git diff --name-only --diff-filter=ACMR \
+              "origin/${{ github.base_ref }}"...HEAD \
+              -- '**/SKILL.md' '**/skills/**' | \
+              grep 'SKILL.md$' | \
+              xargs -I {} dirname {} | \
+              sort -u)
+          else
+            # workflow_dispatch: find all skills
+            CHANGED_SKILLS=$(find . -name "SKILL.md" -not -path "./node_modules/*" -not -path "./.git/*" | \
+              xargs -I {} dirname {} | \
+              sed 's|^\./||' | \
+              sort -u)
+          fi
+
+          if [[ -z "$CHANGED_SKILLS" ]]; then
+            echo "No skill changes detected."
+            echo "skills=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skills to review:"
+            echo "$CHANGED_SKILLS"
+            # Store as newline-delimited string
+            EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "skills<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+            echo "$CHANGED_SKILLS" >> "$GITHUB_OUTPUT"
+            echo "${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run skill reviews
+        if: steps.detect.outputs.skills != ''
+        id: review
+        continue-on-error: true
+        run: |
+          SKILLS="${{ steps.detect.outputs.skills }}"
+          FAILED=0
+          TABLE="| Skill | Status |"
+          TABLE="${TABLE}\n|-------|--------|"
+
+          while IFS= read -r dir; do
+            [[ -z "$dir" ]] && continue
+            echo "::group::Reviewing $dir"
+            RESULT=$(tessl skill review "$dir" 2>&1) || true
+            echo "$RESULT"
+            echo "::endgroup::"
+
+            OVERALL=$(echo "$RESULT" | grep -oP 'Overall: \K(PASSED|FAILED)' || echo "ERROR")
+
+            if [[ "$OVERALL" == "PASSED" ]]; then
+              STATUS="✅ PASSED"
+            else
+              STATUS="❌ FAILED"
+              FAILED=1
+            fi
+
+            TABLE="${TABLE}\n| \`${dir}\` | ${STATUS} |"
+          done <<< "$SKILLS"
+
+          # Write results
+          COMMENT_BODY=$(printf "<!-- tessl-skill-review -->\n## Tessl Skill Review Results\n\n${TABLE}\n\nChecks: frontmatter validity, required fields, body structure, examples, line count.")
+
+          EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "comment<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+          echo "$COMMENT_BODY" >> "$GITHUB_OUTPUT"
+          echo "${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+
+          # Write step summary
+          echo "$COMMENT_BODY" >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$FAILED" -eq 1 ]]; then
+            echo "::error::One or more skills failed validation checks."
+            exit 1
+          fi
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request' && steps.detect.outputs.skills != ''
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const marker = '<!-- tessl-skill-review -->';
+            const body = `${{ steps.review.outputs.comment }}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }
+
+  task-evals:
+    name: Task Evals
+    runs-on: ubuntu-latest
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'run-evals') ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_evals)
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+
+      - name: Install Tessl CLI
+        run: npm install -g @tessl/cli
+
+      - name: Find skills with eval scenarios
+        id: detect
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            SKILL_DIRS=$(git diff --name-only --diff-filter=ACMR \
+              "origin/${{ github.base_ref }}"...HEAD \
+              -- '**/SKILL.md' '**/skills/**' | \
+              grep 'SKILL.md$' | \
+              xargs -I {} dirname {} | \
+              sort -u)
+          else
+            SKILL_DIRS=$(find . -name "SKILL.md" -not -path "./node_modules/*" -not -path "./.git/*" | \
+              xargs -I {} dirname {} | \
+              sed 's|^\./||' | \
+              sort -u)
+          fi
+
+          # Filter to only skills that have eval-scenarios/
+          EVAL_SKILLS=""
+          while IFS= read -r dir; do
+            [[ -z "$dir" ]] && continue
+            if [[ -d "${dir}/eval-scenarios" ]]; then
+              EVAL_SKILLS="${EVAL_SKILLS}${dir}\n"
+            fi
+          done <<< "$SKILL_DIRS"
+          EVAL_SKILLS=$(echo -e "$EVAL_SKILLS" | sed '/^$/d')
+
+          if [[ -z "$EVAL_SKILLS" ]]; then
+            echo "No skills with eval-scenarios/ found."
+            echo "skills=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skills to evaluate:"
+            echo "$EVAL_SKILLS"
+            EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "skills<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+            echo "$EVAL_SKILLS" >> "$GITHUB_OUTPUT"
+            echo "${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run task evals
+        if: steps.detect.outputs.skills != ''
+        id: evals
+        continue-on-error: true
+        run: |
+          SKILLS="${{ steps.detect.outputs.skills }}"
+          FAILED=0
+          TABLE="| Skill | Result |"
+          TABLE="${TABLE}\n|-------|--------|"
+
+          while IFS= read -r dir; do
+            [[ -z "$dir" ]] && continue
+            echo "::group::Evaluating $dir"
+            RESULT=$(tessl eval run "$dir" --force 2>&1) || true
+            echo "$RESULT"
+            echo "::endgroup::"
+
+            if echo "$RESULT" | grep -qi "fail"; then
+              STATUS="❌ FAILED"
+              FAILED=1
+            else
+              STATUS="✅ PASSED"
+            fi
+
+            TABLE="${TABLE}\n| \`${dir}\` | ${STATUS} |"
+          done <<< "$SKILLS"
+
+          COMMENT_BODY=$(printf "<!-- tessl-task-evals -->\n## 🧪 Tessl Task Eval Results\n\n${TABLE}")
+
+          EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "comment<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+          echo "$COMMENT_BODY" >> "$GITHUB_OUTPUT"
+          echo "${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+
+          echo "$COMMENT_BODY" >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$FAILED" -eq 1 ]]; then
+            echo "::error::One or more task evals failed."
+            exit 1
+          fi
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request' && steps.detect.outputs.skills != ''
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const marker = '<!-- tessl-task-evals -->';
+            const body = `${{ steps.evals.outputs.comment }}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body,
+              });
+            }

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -209,6 +209,7 @@ jobs:
     name: Task Evals
     runs-on: ubuntu-latest
     if: >-
+      github.event_name == 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'run-evals') ||
       (github.event_name == 'workflow_dispatch' && inputs.run_evals)
 

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '**/SKILL.md'
       - '**/skills/**'
+      - '.github/workflows/tessl-skill-eval.yml'
   workflow_dispatch:
     inputs:
       run_evals:

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: '20'
 
       - name: Install Tessl CLI
-        run: npm install -g @tessl/cli
+        run: npm install -g @tessl/cli@0.63.2
 
       - name: Detect changed skills
         id: detect
@@ -86,8 +86,8 @@ jobs:
         run: |
           SKILLS="${{ steps.detect.outputs.skills }}"
           FAILED=0
-          TABLE="| Skill | Status |"
-          TABLE="${TABLE}\n|-------|--------|"
+          TABLE="| Skill | Status | Review Score |"
+          TABLE="${TABLE}\n|-------|--------|--------------|"
 
           while IFS= read -r dir; do
             [[ -z "$dir" ]] && continue
@@ -97,19 +97,28 @@ jobs:
             echo "::endgroup::"
 
             OVERALL=$(echo "$RESULT" | grep -oP 'Overall: \K(PASSED|FAILED)' || echo "ERROR")
+            SCORE=$(echo "$RESULT" | grep -oP 'Average Score: \K[0-9]+' || echo "")
 
             if [[ "$OVERALL" == "PASSED" ]]; then
               STATUS="✅ PASSED"
             else
-              STATUS="❌ FAILED"
+              # Extract first validation failure line for context
+              REASON=$(echo "$RESULT" | grep -iE '(FAIL|✗|missing|invalid|error)' | grep -v 'Overall:' | grep -v 'Average Score:' | head -1 | sed 's/^[[:space:]]*//' | cut -c1-80 | tr '|' '/')
+              if [[ -n "$REASON" ]]; then
+                STATUS="❌ FAILED — ${REASON}"
+              else
+                STATUS="❌ FAILED"
+              fi
               FAILED=1
             fi
 
-            TABLE="${TABLE}\n| \`${dir}\` | ${STATUS} |"
+            SCORE_DISPLAY="${SCORE:+${SCORE}%}"
+            SCORE_DISPLAY="${SCORE_DISPLAY:----}"
+            TABLE="${TABLE}\n| \`${dir}\` | ${STATUS} | ${SCORE_DISPLAY} |"
           done <<< "$SKILLS"
 
           # Write results
-          COMMENT_BODY=$(printf "<!-- tessl-skill-review -->\n## Tessl Skill Review Results\n\n${TABLE}\n\nChecks: frontmatter validity, required fields, body structure, examples, line count.")
+          COMMENT_BODY=$(printf "<!-- tessl-skill-review -->\n## Tessl Skill Review Results\n\n${TABLE}\n\nChecks: frontmatter validity, required fields, body structure, examples, line count.\nReview Score is informational — not used for pass/fail gating.")
 
           EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "comment<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"
@@ -175,7 +184,7 @@ jobs:
           node-version: '20'
 
       - name: Install Tessl CLI
-        run: npm install -g @tessl/cli
+        run: npm install -g @tessl/cli@0.63.2
 
       - name: Find skills with eval scenarios
         id: detect

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -1,7 +1,7 @@
 name: Tessl Skill Review
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
     paths:
       - '**/SKILL.md'
@@ -30,7 +30,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -47,7 +46,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
         run: |
-          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
             # Check for eval-scenarios changes and warn
             EVAL_CHANGES=$(git diff --name-only --diff-filter=ACMR \
               "origin/${BASE_REF}"...HEAD -- '**/eval-scenarios/**' || true)
@@ -170,7 +169,7 @@ jobs:
 
       - name: Post or update PR comment
         if: >-
-          github.event_name == 'pull_request_target'
+          github.event_name == 'pull_request'
           && steps.detect.outputs.skills != ''
           && steps.review.outputs.comment != ''
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -216,7 +215,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -233,7 +231,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
         run: |
-          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
             SKILL_DIRS=$(git diff --name-only --diff-filter=ACMR \
               "origin/${BASE_REF}"...HEAD \
               -- '**/SKILL.md' '**/skills/**' | \
@@ -314,7 +312,7 @@ jobs:
 
       - name: Post or update PR comment
         if: >-
-          github.event_name == 'pull_request_target'
+          github.event_name == 'pull_request'
           && steps.detect.outputs.skills != ''
           && steps.evals.outputs.comment != ''
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -149,7 +149,8 @@ jobs:
 
             SCORE_DISPLAY="${SCORE:+${SCORE}%}"
             SCORE_DISPLAY="${SCORE_DISPLAY:----}"
-            TABLE="${TABLE}\n| \`${dir}\` | ${STATUS} | ${SCORE_DISPLAY} |"
+            DIR_DISPLAY=$(echo "$dir" | tr '|' '/')
+            TABLE="${TABLE}\n| \`${DIR_DISPLAY}\` | ${STATUS} | ${SCORE_DISPLAY} |"
           done <<< "$SKILLS"
 
           # Write results

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -19,9 +19,6 @@ permissions:
   contents: read
   pull-requests: write
 
-env:
-  TESSL_TOKEN: ${{ secrets.TESSL_API_KEY }}
-
 jobs:
   review-skills:
     name: Review Skills
@@ -119,6 +116,7 @@ jobs:
         id: review
         env:
           SKILLS: ${{ steps.detect.outputs.skills }}
+          TESSL_TOKEN: ${{ secrets.TESSL_API_KEY }}
         run: |
           FAILED=0
           TABLE="| Skill | Status | Review Score |"
@@ -283,6 +281,7 @@ jobs:
         continue-on-error: true
         env:
           SKILLS: ${{ steps.detect.outputs.skills }}
+          TESSL_TOKEN: ${{ secrets.TESSL_API_KEY }}
         run: |
           FAILED=0
           TABLE="| Skill | Result |"

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -212,7 +212,7 @@ jobs:
     name: Task Evals
     runs-on: ubuntu-latest
     if: >-
-      github.event_name == 'pull_request' ||
+      github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'run-evals') ||
       (github.event_name == 'workflow_dispatch' && inputs.run_evals)
 

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -48,11 +48,13 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            # Check for eval-scenarios changes and warn
+            # Check for eval-scenarios changes and enforce restriction
             EVAL_CHANGES=$(git diff --name-only --diff-filter=ACMR \
               "origin/${BASE_REF}"...HEAD -- '**/eval-scenarios/**' || true)
             if [[ -n "$EVAL_CHANGES" ]]; then
-              echo "::warning::This PR modifies eval-scenarios/ files. These should only be changed by maintainers."
+              echo "::error::This PR modifies eval-scenarios/ files, which should only be changed by maintainers. Changed files:"
+              echo "$EVAL_CHANGES"
+              exit 1
             fi
 
             # Find changed SKILL.md files and extract skill directories

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -173,7 +173,7 @@ jobs:
         if: >-
           github.event_name == 'pull_request'
           && steps.detect.outputs.skills != ''
-          && steps.review.outputs.comment != ''
+          && (steps.review.outcome == 'success' || steps.review.outputs.comment != '')
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           COMMENT_BODY: ${{ steps.review.outputs.comment }}

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -134,7 +134,13 @@ jobs:
 
             OVERALL=$(echo "$RESULT" | sed -n 's/.*Overall: \(PASSED\|FAILED\).*/\1/p' | head -1)
             OVERALL="${OVERALL:-ERROR}"
-            SCORE=$(echo "$RESULT" | sed -n 's/.*Average Score: \([0-9]\{1,\}\).*/\1/p' | head -1)
+            SCORE=$(echo "$RESULT" | sed -n 's/.*Average Score:[[:space:]]\{0,1\}\([0-9]\{1,3\}\(\.[0-9]\+\)\?\).*/\1/p' | head -1)
+            if [[ -n "$SCORE" ]]; then
+              # Validate that SCORE is a number between 0 and 100 (optionally with decimals)
+              if ! [[ "$SCORE" =~ ^([0-9]|[1-9][0-9]|100)(\.[0-9]+)?$ ]]; then
+                SCORE=""
+              fi
+            fi
 
             if [[ "$OVERALL" == "PASSED" ]]; then
               STATUS="PASSED"

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -79,6 +79,34 @@ jobs:
             echo "${EOF_MARKER}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Validate skill directory structure
+        if: steps.detect.outputs.skills != ''
+        run: |
+          SKILLS="${{ steps.detect.outputs.skills }}"
+          INVALID_PATHS=""
+
+          while IFS= read -r dir; do
+            [[ -z "$dir" ]] && continue
+
+            # Expected pattern: <product>/<plugin>/skills/<skill-name>
+            # Examples:
+            #   terraform/code-generation/skills/terraform-style-guide (valid)
+            #   packer/build-machine-image/skills/aws-ami-builder (valid)
+            #   terraform/SKILL.md (invalid - no plugin)
+            #   terraform/code-generation/my-skill (invalid - no skills/ subdirectory)
+
+            if [[ ! "$dir" =~ ^[^/]+/[^/]+/skills/[^/]+$ ]]; then
+              INVALID_PATHS="${INVALID_PATHS}${dir}\n"
+            fi
+          done <<< "$SKILLS"
+
+          if [[ -n "$INVALID_PATHS" ]]; then
+            echo "::error::Skills must follow <product>/<plugin>/skills/<skill-name>/ structure"
+            echo "Invalid paths:"
+            echo -e "$INVALID_PATHS"
+            exit 1
+          fi
+
       - name: Run skill reviews
         if: steps.detect.outputs.skills != ''
         id: review
@@ -100,14 +128,14 @@ jobs:
             SCORE=$(echo "$RESULT" | grep -oP 'Average Score: \K[0-9]+' || echo "")
 
             if [[ "$OVERALL" == "PASSED" ]]; then
-              STATUS="✅ PASSED"
+              STATUS="PASSED"
             else
               # Extract first validation failure line for context
-              REASON=$(echo "$RESULT" | grep -iE '(FAIL|✗|missing|invalid|error)' | grep -v 'Overall:' | grep -v 'Average Score:' | head -1 | sed 's/^[[:space:]]*//' | cut -c1-80 | tr '|' '/')
+              REASON=$(echo "$RESULT" | grep -iE '(FAIL|missing|invalid|error)' | grep -v 'Overall:' | grep -v 'Average Score:' | head -1 | sed 's/^[[:space:]]*//' | cut -c1-80 | tr '|' '/')
               if [[ -n "$REASON" ]]; then
-                STATUS="❌ FAILED — ${REASON}"
+                STATUS="FAILED — ${REASON}"
               else
-                STATUS="❌ FAILED"
+                STATUS="FAILED"
               fi
               FAILED=1
             fi
@@ -243,16 +271,16 @@ jobs:
             echo "::endgroup::"
 
             if echo "$RESULT" | grep -qi "fail"; then
-              STATUS="❌ FAILED"
+              STATUS="FAILED"
               FAILED=1
             else
-              STATUS="✅ PASSED"
+              STATUS="PASSED"
             fi
 
             TABLE="${TABLE}\n| \`${dir}\` | ${STATUS} |"
           done <<< "$SKILLS"
 
-          COMMENT_BODY=$(printf "<!-- tessl-task-evals -->\n## 🧪 Tessl Task Eval Results\n\n${TABLE}")
+          COMMENT_BODY=$(printf "<!-- tessl-task-evals -->\n## Tessl Task Eval Results\n\n${TABLE}")
 
           EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "comment<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -1,7 +1,7 @@
 name: Tessl Skill Review
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     paths:
       - '**/SKILL.md'
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -42,18 +43,21 @@ jobs:
 
       - name: Detect changed skills
         id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
             # Check for eval-scenarios changes and warn
             EVAL_CHANGES=$(git diff --name-only --diff-filter=ACMR \
-              "origin/${{ github.base_ref }}"...HEAD -- '**/eval-scenarios/**' || true)
+              "origin/${BASE_REF}"...HEAD -- '**/eval-scenarios/**' || true)
             if [[ -n "$EVAL_CHANGES" ]]; then
               echo "::warning::This PR modifies eval-scenarios/ files. These should only be changed by maintainers."
             fi
 
             # Find changed SKILL.md files and extract skill directories
             CHANGED_SKILLS=$(git diff --name-only --diff-filter=ACMR \
-              "origin/${{ github.base_ref }}"...HEAD \
+              "origin/${BASE_REF}"...HEAD \
               -- '**/SKILL.md' '**/skills/**' | \
               grep 'SKILL.md$' | \
               xargs -I {} dirname {} | \
@@ -81,8 +85,9 @@ jobs:
 
       - name: Validate skill directory structure
         if: steps.detect.outputs.skills != ''
+        env:
+          SKILLS: ${{ steps.detect.outputs.skills }}
         run: |
-          SKILLS="${{ steps.detect.outputs.skills }}"
           INVALID_PATHS=""
 
           while IFS= read -r dir; do
@@ -111,8 +116,9 @@ jobs:
         if: steps.detect.outputs.skills != ''
         id: review
         continue-on-error: true
+        env:
+          SKILLS: ${{ steps.detect.outputs.skills }}
         run: |
-          SKILLS="${{ steps.detect.outputs.skills }}"
           FAILED=0
           TABLE="| Skill | Status | Review Score |"
           TABLE="${TABLE}\n|-------|--------|--------------|"
@@ -124,8 +130,9 @@ jobs:
             echo "$RESULT"
             echo "::endgroup::"
 
-            OVERALL=$(echo "$RESULT" | grep -oP 'Overall: \K(PASSED|FAILED)' || echo "ERROR")
-            SCORE=$(echo "$RESULT" | grep -oP 'Average Score: \K[0-9]+' || echo "")
+            OVERALL=$(echo "$RESULT" | sed -n 's/.*Overall: \(PASSED\|FAILED\).*/\1/p' | head -1)
+            OVERALL="${OVERALL:-ERROR}"
+            SCORE=$(echo "$RESULT" | sed -n 's/.*Average Score: \([0-9]\{1,\}\).*/\1/p' | head -1)
 
             if [[ "$OVERALL" == "PASSED" ]]; then
               STATUS="PASSED"
@@ -162,12 +169,17 @@ jobs:
           fi
 
       - name: Post or update PR comment
-        if: github.event_name == 'pull_request' && steps.detect.outputs.skills != ''
+        if: >-
+          github.event_name == 'pull_request_target'
+          && steps.detect.outputs.skills != ''
+          && steps.review.outputs.comment != ''
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          COMMENT_BODY: ${{ steps.review.outputs.comment }}
         with:
           script: |
             const marker = '<!-- tessl-skill-review -->';
-            const body = `${{ steps.review.outputs.comment }}`;
+            const body = process.env.COMMENT_BODY;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -204,6 +216,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -216,10 +229,13 @@ jobs:
 
       - name: Find skills with eval scenarios
         id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
             SKILL_DIRS=$(git diff --name-only --diff-filter=ACMR \
-              "origin/${{ github.base_ref }}"...HEAD \
+              "origin/${BASE_REF}"...HEAD \
               -- '**/SKILL.md' '**/skills/**' | \
               grep 'SKILL.md$' | \
               xargs -I {} dirname {} | \
@@ -257,8 +273,9 @@ jobs:
         if: steps.detect.outputs.skills != ''
         id: evals
         continue-on-error: true
+        env:
+          SKILLS: ${{ steps.detect.outputs.skills }}
         run: |
-          SKILLS="${{ steps.detect.outputs.skills }}"
           FAILED=0
           TABLE="| Skill | Result |"
           TABLE="${TABLE}\n|-------|--------|"
@@ -266,11 +283,12 @@ jobs:
           while IFS= read -r dir; do
             [[ -z "$dir" ]] && continue
             echo "::group::Evaluating $dir"
-            RESULT=$(tessl eval run "$dir" --force 2>&1) || true
+            EXIT_CODE=0
+            RESULT=$(tessl eval run "$dir" --force 2>&1) || EXIT_CODE=$?
             echo "$RESULT"
             echo "::endgroup::"
 
-            if echo "$RESULT" | grep -qi "fail"; then
+            if [[ "$EXIT_CODE" -ne 0 ]]; then
               STATUS="FAILED"
               FAILED=1
             else
@@ -295,12 +313,17 @@ jobs:
           fi
 
       - name: Post or update PR comment
-        if: github.event_name == 'pull_request' && steps.detect.outputs.skills != ''
+        if: >-
+          github.event_name == 'pull_request_target'
+          && steps.detect.outputs.skills != ''
+          && steps.evals.outputs.comment != ''
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          COMMENT_BODY: ${{ steps.evals.outputs.comment }}
         with:
           script: |
             const marker = '<!-- tessl-task-evals -->';
-            const body = `${{ steps.evals.outputs.comment }}`;
+            const body = process.env.COMMENT_BODY;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -117,7 +117,6 @@ jobs:
       - name: Run skill reviews
         if: steps.detect.outputs.skills != ''
         id: review
-        continue-on-error: true
         env:
           SKILLS: ${{ steps.detect.outputs.skills }}
         run: |

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -249,14 +249,14 @@ jobs:
           fi
 
           # Filter to only skills that have eval-scenarios/
-          EVAL_SKILLS=""
-          while IFS= read -r dir; do
-            [[ -z "$dir" ]] && continue
-            if [[ -d "${dir}/eval-scenarios" ]]; then
-              EVAL_SKILLS="${EVAL_SKILLS}${dir}\n"
-            fi
-          done <<< "$SKILL_DIRS"
-          EVAL_SKILLS=$(echo -e "$EVAL_SKILLS" | sed '/^$/d')
+          EVAL_SKILLS=$(
+            while IFS= read -r dir; do
+              [[ -z "$dir" ]] && continue
+              if [[ -d "${dir}/eval-scenarios" ]]; then
+                printf '%s\n' "$dir"
+              fi
+            done <<< "$SKILL_DIRS"
+          )
 
           if [[ -z "$EVAL_SKILLS" ]]; then
             echo "No skills with eval-scenarios/ found."

--- a/.github/workflows/tessl-skill-eval.yml
+++ b/.github/workflows/tessl-skill-eval.yml
@@ -216,8 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'run-evals') ||
-      (github.event_name == 'workflow_dispatch' && inputs.run_evals)
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.run_evals == 'true')
 
     steps:
       - name: Checkout repository
@@ -278,7 +277,7 @@ jobs:
       - name: Run task evals
         if: steps.detect.outputs.skills != ''
         id: evals
-        continue-on-error: true
+
         env:
           SKILLS: ${{ steps.detect.outputs.skills }}
           TESSL_TOKEN: ${{ secrets.TESSL_API_KEY }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/tessl-skill-eval.yml`) that runs automated skill reviews and enforces directory structure conventions on PRs targeting `main`.

## Implementation

### New workflow: `tessl-skill-eval.yml`

Two jobs:

| Job | Purpose |
|-----|---------|
| `review-skills` | Detects changed skills, validates directory structure, runs Tessl LLM-judge reviews, posts results as a PR comment |
| `task-evals` | Opt-in task-based evaluations triggered by `run-evals` label or `workflow_dispatch` |

### Directory structure validation
- Enforces `<product>/<plugin>/skills/<skill-name>/` pattern via regex (`^[^/]+/[^/]+/skills/[^/]+$`)
- Runs after skill detection, before reviews
- Fails fast with clear error messages listing invalid paths

### Review score reporting
- Runs `@tessl/cli@0.63.2` skill review on changed skills
- Extracts average score and displays it as a percentage in the PR comment table
- Informational only — does not gate pass/fail

### Failure context
- Extracts first validation failure line from CLI output
- Shows reason inline in PR comment table so contributors can fix issues without digging through Actions logs

## Test Plan

- [ ] PRs with valid `<product>/<plugin>/skills/<skill-name>/` paths pass validation
- [ ] PRs with invalid directory structures fail with clear error messages
- [ ] Review scores display correctly in PR comment table
- [ ] Failure reasons appear inline in PR comments
- [ ] Workflow triggers on PRs that touch skill files
- [ ] `task-evals` job triggers only with `run-evals` label or manual dispatch