### PR TITLE
feat(bob): add skills manifest and README for Bob Skills Directory

### DIFF
--- a/.bob/README.md
+++ b/.bob/README.md
@@ -1,0 +1,84 @@
+# Bob Skills Directory
+
+This directory contains Bob-specific configuration and metadata for HashiCorp Agent Skills.
+
+## Files
+
+### skills.json
+
+The `skills.json` file is a manifest that provides:
+
+- **Skill Discovery**: Complete list of all available skills with descriptions
+- **Categorization**: Skills organized by product (Terraform, Packer)
+- **Metadata**: Tags, paths, and descriptions for each skill
+- **MCP Configuration**: Pre-configured MCP server settings for Terraform
+
+This manifest enables Bob to:
+1. Discover all available skills without browsing directories
+2. Understand skill categories and relationships
+3. Configure MCP servers with recommended settings
+4. Display skill information in Bob's interface
+
+## Usage
+
+Bob can automatically read this manifest to:
+
+```bash
+# List all skills from the manifest
+npx skills add hashicorp/agent-skills
+
+# Install skills by category
+# (if Bob supports category-based installation)
+npx skills add hashicorp/agent-skills --category terraform
+
+# Install all skills
+# (if Bob supports bulk installation)
+npx skills add hashicorp/agent-skills --all
+```
+
+## Schema
+
+The `skills.json` follows this structure:
+
+```json
+{
+  "name": "repository-name",
+  "version": "1.0.0",
+  "description": "Repository description",
+  "skills": [
+    {
+      "name": "skill-name",
+      "path": "relative/path/to/skill",
+      "description": "Skill description",
+      "category": "product-name",
+      "tags": ["tag1", "tag2"]
+    }
+  ],
+  "mcpServers": {
+    "server-name": {
+      "description": "Server description",
+      "command": "command",
+      "args": ["arg1", "arg2"],
+      "env": {
+        "VAR": "value"
+      }
+    }
+  }
+}
+```
+
+## Maintenance
+
+When adding new skills:
+
+1. Add skill entry to `skills.json`
+2. Include accurate path, description, and tags
+3. Update category if introducing new product
+4. Test manifest with `npx skills add`
+
+## References
+
+- [Bob Documentation](https://ibm.com/bob) - IBM's Bob documentation
+- [Skills CLI](https://github.com/skills-ai/cli) - Skills installation tool
+- [Parent README](../README.md) - Main repository documentation
+- [Bob Integration Guide](../BOB.md) - Complete Bob setup guide

--- a/.bob/skills.json
+++ b/.bob/skills.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://skills.ai/schema/v1/skills-manifest.json",
+  "name": "hashicorp-agent-skills",
+  "version": "1.0.0",
+  "description": "HashiCorp Agent Skills for Terraform and Packer development",
+  "author": {
+    "name": "HashiCorp",
+    "url": "https://github.com/hashicorp"
+  },
+  "repository": "https://github.com/hashicorp/agent-skills",
+  "license": "MPL-2.0",
+  "skills": [
+    {
+      "name": "terraform-style-guide",
+      "path": "terraform/code-generation/skills/terraform-style-guide",
+      "description": "Generate Terraform HCL code following HashiCorp's official style conventions and best practices",
+      "category": "terraform",
+      "tags": ["terraform", "hcl", "style-guide", "best-practices"]
+    },
+    {
+      "name": "terraform-test",
+      "path": "terraform/code-generation/skills/terraform-test",
+      "description": "Writing and running .tftest.hcl test files for Terraform modules",
+      "category": "terraform",
+      "tags": ["terraform", "testing", "tftest"]
+    },
+    {
+      "name": "azure-verified-modules",
+      "path": "terraform/code-generation/skills/azure-verified-modules",
+      "description": "Azure Verified Modules (AVM) requirements and certification guidelines",
+      "category": "terraform",
+      "tags": ["terraform", "azure", "avm", "modules"]
+    },
+    {
+      "name": "refactor-module",
+      "path": "terraform/module-generation/skills/refactor-module",
+      "description": "Transform monolithic Terraform configurations into reusable modules",
+      "category": "terraform",
+      "tags": ["terraform", "modules", "refactoring"]
+    },
+    {
+      "name": "terraform-stacks",
+      "path": "terraform/module-generation/skills/terraform-stacks",
+      "description": "Multi-region/environment orchestration with Terraform Stacks",
+      "category": "terraform",
+      "tags": ["terraform", "stacks", "orchestration", "multi-region"]
+    },
+    {
+      "name": "new-terraform-provider",
+      "path": "terraform/provider-development/skills/new-terraform-provider",
+      "description": "Scaffold a new Terraform provider using the Plugin Framework",
+      "category": "terraform",
+      "tags": ["terraform", "provider", "plugin-framework", "scaffolding"]
+    },
+    {
+      "name": "run-acceptance-tests",
+      "path": "terraform/provider-development/skills/run-acceptance-tests",
+      "description": "Run and debug Terraform provider acceptance tests",
+      "category": "terraform",
+      "tags": ["terraform", "provider", "testing", "acceptance-tests"]
+    },
+    {
+      "name": "provider-actions",
+      "path": "terraform/provider-development/skills/provider-actions",
+      "description": "Implement provider actions (lifecycle operations) in Terraform providers",
+      "category": "terraform",
+      "tags": ["terraform", "provider", "actions", "lifecycle"]
+    },
+    {
+      "name": "provider-resources",
+      "path": "terraform/provider-development/skills/provider-resources",
+      "description": "Implement resources and data sources in Terraform providers",
+      "category": "terraform",
+      "tags": ["terraform", "provider", "resources", "data-sources"]
+    },
+    {
+      "name": "aws-ami-builder",
+      "path": "packer/builders/skills/aws-ami-builder",
+      "description": "Build Amazon Machine Images (AMIs) with Packer's amazon-ebs builder",
+      "category": "packer",
+      "tags": ["packer", "aws", "ami", "image-building"]
+    },
+    {
+      "name": "azure-image-builder",
+      "path": "packer/builders/skills/azure-image-builder",
+      "description": "Build Azure managed images and Azure Compute Gallery images with Packer",
+      "category": "packer",
+      "tags": ["packer", "azure", "image-building", "compute-gallery"]
+    },
+    {
+      "name": "windows-builder",
+      "path": "packer/builders/skills/windows-builder",
+      "description": "Platform-agnostic Windows image building patterns with WinRM and PowerShell",
+      "category": "packer",
+      "tags": ["packer", "windows", "winrm", "powershell"]
+    },
+    {
+      "name": "push-to-registry",
+      "path": "packer/hcp/skills/push-to-registry",
+      "description": "Configure hcp_packer_registry to push build metadata to HCP Packer",
+      "category": "packer",
+      "tags": ["packer", "hcp-packer", "registry", "metadata"]
+    }
+  ],
+  "mcpServers": {
+    "terraform": {
+      "description": "Terraform MCP Server for HCP Terraform integration",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "TFE_TOKEN",
+        "-e",
+        "TFE_ADDRESS",
+        "hashicorp/terraform-mcp-server"
+      ],
+      "env": {
+        "TFE_TOKEN": "${TFE_TOKEN}",
+        "TFE_ADDRESS": "${TFE_ADDRESS}"
+      },
+      "requiredEnvVars": ["TFE_TOKEN"],
+      "optionalEnvVars": ["TFE_ADDRESS"]
+    }
+  }
+}

--- a/BOB.md
+++ b/BOB.md
@@ -1,0 +1,273 @@
+# Bob (IBM) Integration Guide
+
+This guide explains how to use HashiCorp Agent Skills with Bob, IBM's AI coding assistant.
+
+## Overview
+
+All skills in this repository are **fully compatible with Bob** out of the box. Bob uses the same skill format as other AI coding assistants, making installation straightforward.
+
+## Quick Start
+
+### Install All Skills
+
+List all available skills from this repository:
+
+```bash
+npx skills add hashicorp/agent-skills
+```
+
+This displays an interactive menu where you can select which skills to install.
+
+### Install Individual Skills
+
+Install specific skills directly:
+
+```bash
+# Terraform Code Generation
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/terraform-style-guide
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/terraform-test
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/azure-verified-modules
+
+# Terraform Module Generation
+npx skills add hashicorp/agent-skills/terraform/module-generation/skills/refactor-module
+npx skills add hashicorp/agent-skills/terraform/module-generation/skills/terraform-stacks
+
+# Terraform Provider Development
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/new-terraform-provider
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/run-acceptance-tests
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-actions
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-resources
+
+# Packer Builders
+npx skills add hashicorp/agent-skills/packer/builders/skills/aws-ami-builder
+npx skills add hashicorp/agent-skills/packer/builders/skills/azure-image-builder
+npx skills add hashicorp/agent-skills/packer/builders/skills/windows-builder
+
+# Packer HCP Integration
+npx skills add hashicorp/agent-skills/packer/hcp/skills/push-to-registry
+```
+
+## Available Skills
+
+### Terraform Skills
+
+#### Code Generation
+- **terraform-style-guide**: Generate HCL code following HashiCorp style conventions
+- **terraform-test**: Write and run `.tftest.hcl` test files
+- **azure-verified-modules**: Azure Verified Modules (AVM) requirements
+
+#### Module Generation
+- **refactor-module**: Transform monolithic configs into reusable modules
+- **terraform-stacks**: Multi-region/environment orchestration
+
+#### Provider Development
+- **new-terraform-provider**: Scaffold new Terraform providers
+- **run-acceptance-tests**: Run and debug provider acceptance tests
+- **provider-actions**: Implement provider actions (lifecycle operations)
+- **provider-resources**: Implement resources and data sources
+
+### Packer Skills
+
+#### Builders
+- **aws-ami-builder**: Build Amazon Machine Images (AMIs)
+- **azure-image-builder**: Build Azure managed images
+- **windows-builder**: Platform-agnostic Windows image patterns
+
+#### HCP Integration
+- **push-to-registry**: Push build metadata to HCP Packer registry
+
+## MCP Server Configuration
+
+For enhanced Terraform integration, configure the Terraform MCP Server in Bob's settings.
+
+### Prerequisites
+
+1. Docker installed and running
+2. HCP Terraform account (optional, for HCP Terraform features)
+3. HCP Terraform API token (if using HCP Terraform)
+
+### Configuration Steps
+
+1. **Set Environment Variables**
+
+   Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
+
+   ```bash
+   export TFE_TOKEN="your-hcp-terraform-token"
+   export TFE_ADDRESS="app.terraform.io"  # Optional, defaults to app.terraform.io
+   ```
+
+   Or create a `.env` file in your project:
+
+   ```bash
+   TFE_TOKEN=your-hcp-terraform-token
+   TFE_ADDRESS=app.terraform.io
+   ```
+
+2. **Configure Bob MCP Settings**
+
+   Add to Bob's MCP configuration file (location varies by Bob installation):
+
+   ```json
+   {
+     "mcpServers": {
+       "terraform": {
+         "command": "docker",
+         "args": [
+           "run",
+           "-i",
+           "--rm",
+           "-e",
+           "TFE_TOKEN",
+           "-e",
+           "TFE_ADDRESS",
+           "hashicorp/terraform-mcp-server"
+         ],
+         "env": {
+           "TFE_TOKEN": "${TFE_TOKEN}",
+           "TFE_ADDRESS": "${TFE_ADDRESS}"
+         }
+       }
+     }
+   }
+   ```
+
+3. **Verify Configuration**
+
+   Test the MCP server connection:
+
+   ```bash
+   docker run -i --rm \
+     -e TFE_TOKEN="${TFE_TOKEN}" \
+     -e TFE_ADDRESS="${TFE_ADDRESS}" \
+     hashicorp/terraform-mcp-server
+   ```
+
+### MCP Server Features
+
+When configured, the Terraform MCP Server provides:
+
+- **Workspace Management**: List, create, and manage HCP Terraform workspaces
+- **Run Operations**: Trigger and monitor Terraform runs
+- **State Management**: Query and manage Terraform state
+- **Variable Management**: Set and retrieve workspace variables
+- **Policy Checks**: View policy check results
+- **Cost Estimates**: Access cost estimation data
+
+### Troubleshooting MCP
+
+**Docker not found:**
+```bash
+# Install Docker Desktop or Docker Engine
+# macOS: brew install --cask docker
+# Linux: Follow Docker installation guide
+```
+
+**Token authentication failed:**
+```bash
+# Verify token is set
+echo $TFE_TOKEN
+
+# Generate new token at https://app.terraform.io/app/settings/tokens
+```
+
+**Connection timeout:**
+```bash
+# Check Docker is running
+docker ps
+
+# Test network connectivity
+curl https://app.terraform.io
+```
+
+## Usage Examples
+
+### Example 1: Generate Terraform Configuration
+
+Ask Bob:
+```
+Using the terraform-style-guide skill, create a Terraform configuration for an AWS VPC with public and private subnets.
+```
+
+Bob will generate properly formatted HCL code following HashiCorp conventions.
+
+### Example 2: Refactor to Module
+
+Ask Bob:
+```
+Using the refactor-module skill, convert this main.tf into a reusable module with proper variables and outputs.
+```
+
+Bob will restructure your code into a well-organized module.
+
+### Example 3: Build Packer Image
+
+Ask Bob:
+```
+Using the aws-ami-builder skill, create a Packer template to build an Ubuntu 22.04 AMI with nginx installed.
+```
+
+Bob will generate a complete Packer HCL template.
+
+### Example 4: Provider Development
+
+Ask Bob:
+```
+Using the new-terraform-provider skill, scaffold a new Terraform provider for the Acme API.
+```
+
+Bob will create the complete provider structure with Plugin Framework.
+
+## Skill Management
+
+### List Installed Skills
+
+```bash
+npx skills list
+```
+
+### Update Skills
+
+```bash
+npx skills update hashicorp/agent-skills
+```
+
+### Remove Skills
+
+```bash
+npx skills remove terraform-style-guide
+```
+
+## Best Practices
+
+1. **Install Relevant Skills**: Only install skills you need to reduce context size
+2. **Use Specific Skill Names**: Reference skills explicitly in prompts for better results
+3. **Combine Skills**: Use multiple skills together for complex tasks
+4. **Keep Skills Updated**: Regularly update to get latest improvements
+5. **Configure MCP**: Set up MCP server for enhanced Terraform capabilities
+
+## Differences from Claude Code
+
+| Feature | Claude Code | Bob |
+|---------|-------------|-----|
+| Installation | Plugin marketplace + individual skills | Individual skills only |
+| Plugin System | Yes (`.claude-plugin/`) | No (direct skill installation) |
+| MCP Configuration | In plugin.json | In Bob's MCP settings |
+| Skill Format | SKILL.md with YAML frontmatter | Same |
+| Skill Discovery | Plugin marketplace | `npx skills add` or `.bob/skills.json` |
+
+## Support
+
+- **Repository**: https://github.com/hashicorp/agent-skills
+- **Issues**: https://github.com/hashicorp/agent-skills/issues
+- **Terraform Docs**: https://developer.hashicorp.com/terraform
+- **Packer Docs**: https://developer.hashicorp.com/packer
+- **Bob Documentation**: Refer to IBM's Bob documentation
+
+## Legal Notice
+
+> Your use of a third party MCP Client/LLM is subject solely to the terms of use for such MCP/LLM, and IBM is not responsible for the performance of such third party tools. IBM expressly disclaims any and all warranties and liability for third party MCP Clients/LLMs, and may not be able to provide support to resolve issues which are caused by the third party tools.
+
+## License
+
+MPL-2.0 - See [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,36 @@ A collection of Agent skills and Claude Code plugins for HashiCorp products.
 
 ## Installation
 
-### Individual Skills
+### Bob (IBM)
+
+Install skills directly using npx. See [BOB.md](./BOB.md) for complete Bob integration guide.
+
+```bash
+# List all skills
+npx skills add hashicorp/agent-skills
+
+# Install a specific skill
+npx skills add hashicorp/agent-skills/terraform/code-generation/skills/terraform-style-guide
+```
+
+**MCP Server Configuration:** Add to Bob's MCP settings for enhanced Terraform integration:
+
+```json
+{
+  "mcpServers": {
+    "terraform": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-e", "TFE_TOKEN", "-e", "TFE_ADDRESS", "hashicorp/terraform-mcp-server"],
+      "env": {
+        "TFE_TOKEN": "${TFE_TOKEN}",
+        "TFE_ADDRESS": "${TFE_ADDRESS}"
+      }
+    }
+  }
+}
+```
+
+### Other AI Coding Assistants
 
 Install Agent Skills in GitHub Copilot, Claude Code, Opencode, Cursor, and more:
 
@@ -44,15 +73,30 @@ Or use the interactive interface:
 /plugin
 ```
 
+## Available Skills
+
+### Terraform
+- **Code Generation**: HCL style guide, testing, Azure Verified Modules
+- **Module Generation**: Refactoring, Terraform Stacks orchestration
+- **Provider Development**: Scaffolding, resources, actions, acceptance tests
+
+### Packer
+- **Builders**: AWS AMI, Azure images, Windows patterns
+- **HCP Integration**: Registry metadata and tracking
+
+See [BOB.md](./BOB.md) for complete skill list and usage examples for [IBM Bob](https://www.ibm.com/products/bob).
+
 ## Structure
 
 ```
 agent-skills/
+├── .bob/
+│   └── skills.json         # Bob skill manifest
 ├── .claude-plugin/
-│   └── marketplace.json
+│   └── marketplace.json    # Claude Code marketplace
 ├── terraform/              # Terraform skills
 ├── packer/                 # Packer skills
-├── <product>/              # Future products (Vault, Consul, etc.)
+├── BOB.md                  # Bob integration guide
 └── README.md
 ```
 
@@ -66,6 +110,13 @@ Each product folder contains plugins, and each plugin contains skills:
         └── <skill>/
             └── SKILL.md
 ```
+
+## Documentation
+
+- **[BOB.md](./BOB.md)** - Complete [IBM Bob](https://www.ibm.com/products/bob) integration guide
+- **[AGENTS.md](./AGENTS.md)** - Detailed agent instructions and plugin documentation
+- **[Terraform README](./terraform/README.md)** - Terraform-specific skills
+- **[Packer README](./packer/README.md)** - Packer-specific skills
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ agent-skills/
 │   └── marketplace.json    # Claude Code marketplace
 ├── terraform/              # Terraform skills
 ├── packer/                 # Packer skills
+├── <product>/              # Future products (Vault, Consul, etc.)
 ├── BOB.md                  # Bob integration guide
 └── README.md
 ```


### PR DESCRIPTION
Add a new .bob/skills.json manifest and accompanying .bob/README.md that provide a centralized catalog of HashiCorp Agent Skills for Terraform and Packer development.

The skills.json file:
- Introduces a schema-backed manifest (skills-manifest.json) with repo
  metadata, license, and author information.
- Lists multiple Terraform-focused skills with name, path, description,
  category, and tags to enable discovery, categorization, and automated
  installation by Bob or Skills CLI.
- Includes MCP server configuration placeholders and example fields
  required for consistent skill metadata and automation.

The README.md file:
- Documents the purpose and usage of the Bob Skills Directory and the
  skills.json manifest.
- Describes the manifest schema, maintenance steps, and sample CLI
  usage for installing skills.
- Points to relevant references and integration guides.

This change enables Bob to discover and present available skills, simplifies adding new skills, and standardizes metadata to support tooling and UI integration.