### PR TITLE
terraform-stacks: describe .terraform-version file

### DIFF
--- a/terraform/module-generation/skills/terraform-stacks/SKILL.md
+++ b/terraform/module-generation/skills/terraform-stacks/SKILL.md
@@ -34,6 +34,7 @@ All configuration files must be at the root level of the Stack repository. HCP T
 
 ```
 my-stack/
+├── .terraform-version               # The required Terraform version for this Stack
 ├── variables.tfcomponent.hcl        # Variable declarations
 ├── providers.tfcomponent.hcl        # Provider configurations
 ├── components.tfcomponent.hcl       # Component definitions
@@ -52,6 +53,17 @@ my-stack/
 - Git: `git::https://github.com/org/repo.git//path?ref=v1.0.0`
 
 HCP Terraform processes all `.tfcomponent.hcl` and `.tfdeploy.hcl` files in dependency order.
+
+## Required Terraform version (.terraform-version)
+
+Use Terraform v1.13.x or later to access the Stacks CLI plugin and to run
+terraform stacks CLI commands. Begin by adding a .terraform-version file to
+your Stack's root directory to specify the Terraform version required for your
+Stack. For example, the following file specifies Terraform v1.14.5:
+
+```
+1.14.5
+```
 
 ## Component Configuration (.tfcomponent.hcl)
 


### PR DESCRIPTION
An improvement, extracted from this session:
```
⏺ Bash(\
        terraform stacks configuration upload \…)
  ⎿  Error: Exit code 1
     ╷
     │ Error: Missing .terraform-version file
     │
     │ Terraform Stacks requires a .terraform-version file alongside the root .tfcomponent.hcl files.
     ╵
     ╷
     │ Warning: Deprecated Resource
     │
     │   on ./modules/hats/main.tf line 9, in resource "kubernetes_namespace" "hats":
     … +20 lines (ctrl+o to see all)

⏺ Two fixes needed: a .terraform-version file and update the deprecated kubernetes_namespace resource to
  kubernetes_namespace_v1. Let me do both in parallel.

⏺ Bash(terraform version -json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['terraform_version'])")
  ⎿  1.14.5

⏺ Write(.terraform-version)
  ⎿  Wrote 1 lines to .terraform-version
      1 1.14.5
```

cc: @shernandez5 ℹ️ 