### PR TITLE
fix: pin terraform-mcp-server Docker image to explicit version tag

### DIFF
--- a/terraform/code-generation/.claude-plugin/plugin.json
+++ b/terraform/code-generation/.claude-plugin/plugin.json
@@ -19,7 +19,7 @@
         "--rm",
         "-e", "TFE_TOKEN",
         "-e", "TFE_ADDRESS",
-        "hashicorp/terraform-mcp-server"
+        "hashicorp/terraform-mcp-server:0.5.0"
       ],
       "env": {
         "TFE_TOKEN": "${TFE_TOKEN}",

--- a/terraform/module-generation/.claude-plugin/plugin.json
+++ b/terraform/module-generation/.claude-plugin/plugin.json
@@ -19,7 +19,7 @@
         "--rm",
         "-e", "TFE_TOKEN",
         "-e", "TFE_ADDRESS",
-        "hashicorp/terraform-mcp-server"
+        "hashicorp/terraform-mcp-server:0.5.0"
       ],
       "env": {
         "TFE_TOKEN": "${TFE_TOKEN}",


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Both `terraform/code-generation/.claude-plugin/plugin.json` and `terraform/module-generation/.claude-plugin/plugin.json` reference the MCP server image as `hashicorp/terraform-mcp-server` without a version tag. Docker resolves untagged references to `latest`, which means:

- The image pulled can change silently between installs, making setups non-reproducible.
- Users have no auditable record of which version of the MCP server they are running alongside sensitive credentials (TFE_TOKEN).
- A supply-chain compromise of the `latest` tag would affect all users without warning.

## Fix

Pin both plugin manifests to the current stable release tag `0.5.0`:

```diff
- "hashicorp/terraform-mcp-server"
+ "hashicorp/terraform-mcp-server:0.5.0"
```

The `0.5.0` tag was confirmed from the [terraform-mcp-server releases](https://github.com/hashicorp/terraform-mcp-server/releases). When a newer version is released, the tag can be intentionally bumped in a deliberate commit.

## Why it matters

This image receives `TFE_TOKEN` — a Terraform Enterprise API credential. Pinning to an explicit version ensures users can verify exactly what runs with that credential, and prevents unexpected breakage when `latest` advances.