### PR TITLE
docs: add integrity warning to Chocolatey iex install example

### DIFF
--- a/packer/builders/skills/windows-builder/SKILL.md
+++ b/packer/builders/skills/windows-builder/SKILL.md
@@ -100,6 +100,11 @@ build {
   sources = ["source.amazon-ebs.windows"]
 
   # Install Chocolatey
+  # NOTE: The iex + DownloadString pattern executes a remote script directly in
+  # memory without verifying its integrity. For production images, consider using
+  # the official signed installer from https://chocolatey.org/install or
+  # verifying the downloaded script's checksum before execution.
+  # See: https://docs.chocolatey.org/en-us/choco/setup/#more-install-options
   provisioner "powershell" {
     inline = [
       "Set-ExecutionPolicy Bypass -Scope Process -Force",


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Issue

`packer/builders/skills/windows-builder/SKILL.md` (line 106) shows a Chocolatey install using the `iex` + `DownloadString` pattern:

```powershell
iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
```

This is the PowerShell equivalent of `curl | sh` — it fetches and executes a remote script entirely in memory, with no integrity check (no checksum, no signature verification). When this pattern appears in a documentation example without a caveat, it can lead users to adopt it in production image builds without understanding the risk.

## Fix

Add a comment block before the provisioner explaining the risk and pointing to the Chocolatey docs for more secure alternatives (signed installer, checksum verification). The example code itself is unchanged — only a warning comment is added.

## Why it matters

Packer templates are often used to build golden AMIs or base images for production workloads. Users following this example in a CI/CD pipeline would silently accept whatever `community.chocolatey.org` serves at build time, with no audit trail. A brief note helps users make an informed choice without removing a useful example.

No functional code was changed in this PR.