### PR TITLE
feat: add ephemeral resource guidance to terraform-style-guide

### DIFF
--- a/.github/workflows/tessl-skill-review.yml
+++ b/.github/workflows/tessl-skill-review.yml
@@ -204,6 +204,8 @@ jobs:
             DIR_DISPLAY=$(echo "$dir" | tr '|' '/')
             TABLE="${TABLE}\\n| \\`${DIR_DISPLAY}\\` | ${STATUS} | ${AVG_SCORE}% | ${CHANGE} |"
 
+            echo "Validate dimension scores..."
+
             # Calculate dimension scores for cache and details
             DESC_SCORE=$(echo "$JSON" | jq -r '
               (.descriptionJudge.evaluation.scores | to_entries | map(.value.score) | add) * 100 / ((.descriptionJudge.evaluation.scores | length) * 3) | round
@@ -221,6 +223,8 @@ jobs:
               echo "::warning::Invalid content score for $dir: $CONTENT_SCORE, using 0"
               CONTENT_SCORE=0
             fi
+
+            ec
 
             # --- Extract detailed review for collapsible section ---
             DESC_EVAL=$(echo "$JSON" | jq -r '.descriptionJudge.evaluation |
@@ -396,70 +400,70 @@ jobs:
           path: cache-entries.tsv
           retention-days: 1
 
-      - name: Save PR comment artifact
-        if: >-
-          github.event_name == 'pull_request'
-          && steps.detect.outputs.skills != ''
-          && (steps.review.outcome == 'success' || steps.review.outputs.comment != '')
-        env:
-          COMMENT_BODY: ${{ steps.review.outputs.comment }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          mkdir -p pr-comment
-          echo "$PR_NUMBER" > pr-comment/pr_number
-          echo "$COMMENT_BODY" > pr-comment/comment.md
+      # - name: Save PR comment artifact
+      #   if: >-
+      #     github.event_name == 'pull_request'
+      #     && steps.detect.outputs.skills != ''
+      #     && (steps.review.outcome == 'success' || steps.review.outputs.comment != '')
+      #   env:
+      #     COMMENT_BODY: ${{ steps.review.outputs.comment }}
+      #     PR_NUMBER: ${{ github.event.pull_request.number }}
+      #   run: |
+      #     mkdir -p pr-comment
+      #     echo "$PR_NUMBER" > pr-comment/pr_number
+      #     echo "$COMMENT_BODY" > pr-comment/comment.md
 
-      - name: Upload PR comment artifact
-        if: >-
-          github.event_name == 'pull_request'
-          && steps.detect.outputs.skills != ''
-          && (steps.review.outcome == 'success' || steps.review.outputs.comment != '')
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: skill-review-comment
-          path: pr-comment/
+      # - name: Upload PR comment artifact
+      #   if: >-
+      #     github.event_name == 'pull_request'
+      #     && steps.detect.outputs.skills != ''
+      #     && (steps.review.outcome == 'success' || steps.review.outputs.comment != '')
+      #   uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      #   with:
+      #     name: skill-review-comment
+      #     path: pr-comment/
 
-  commit-cache:
-    name: Commit Cache
-    runs-on: ubuntu-latest
-    needs: review-skills
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: write
+  # commit-cache:
+  #   name: Commit Cache
+  #   runs-on: ubuntu-latest
+  #   needs: review-skills
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  #   permissions:
+  #     contents: write
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Download cache file
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: skill-review-cache
+  #     - name: Download cache file
+  #       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+  #       with:
+  #         name: skill-review-cache
 
-      - name: Move cache to correct location
-        run: |
-          mkdir -p .github/.tessl
-          mv skill-review-cache.json .github/.tessl/skill-review-cache.json
+  #     - name: Move cache to correct location
+  #       run: |
+  #         mkdir -p .github/.tessl
+  #         mv skill-review-cache.json .github/.tessl/skill-review-cache.json
 
-      - name: Check for cache changes
-        id: check
-        run: |
-          if git diff --quiet HEAD .github/.tessl/skill-review-cache.json; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
+  #     - name: Check for cache changes
+  #       id: check
+  #       run: |
+  #         if git diff --quiet HEAD .github/.tessl/skill-review-cache.json; then
+  #           echo "changed=false" >> "$GITHUB_OUTPUT"
+  #         else
+  #           echo "changed=true" >> "$GITHUB_OUTPUT"
+  #         fi
 
-      - name: Commit cache
-        if: steps.check.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .github/.tessl/skill-review-cache.json
-          git commit -m "chore: update skill review cache [skip ci]"
-          if ! git push; then
-            echo "::error::Failed to push cache update to main"
-            exit 1
-          fi
+  #     - name: Commit cache
+  #       if: steps.check.outputs.changed == 'true'
+  #       run: |
+  #         git config user.name "github-actions[bot]"
+  #         git config user.email "github-actions[bot]@users.noreply.github.com"
+  #         git add .github/.tessl/skill-review-cache.json
+  #         git commit -m "chore: update skill review cache [skip ci]"
+  #         if ! git push; then
+  #           echo "::error::Failed to push cache update to main"
+  #           exit 1
+  #         fi

--- a/terraform/code-generation/skills/terraform-style-guide/SECURITY.md
+++ b/terraform/code-generation/skills/terraform-style-guide/SECURITY.md
@@ -1,0 +1,166 @@
+---
+name: terraform-style-guide-security
+description: Generate Terraform HCL code following HashiCorp's security practices
+---
+
+# Terraform Style Guide - Security
+
+When generating code, apply security hardening:
+
+- Enable encryption at rest by default
+- Configure private networking where applicable
+- Apply principle of least privilege for security groups
+- Enable logging and monitoring
+- Never hardcode credentials or secrets
+- Mark sensitive outputs with `sensitive = true`
+- Use `ephemeral` resources and write-only attributes
+  for sensitive data not stored in a secrets manager
+
+## Example: Secure S3 Bucket
+
+```hcl
+resource "aws_s3_bucket" "data" {
+  bucket = "${var.project}-${var.environment}-data"
+  tags   = local.common_tags
+}
+
+resource "aws_s3_bucket_versioning" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.s3.arn
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+```
+
+## Ephemeral resources
+
+Ephemeral resources prevent sensitive data being stored in state.
+For more information on ephemeral resources, see the
+[Terraform documentation](https://developer.hashicorp.com/terraform/language/block/ephemeral).
+
+Follow this priority order for managing sensitive attributes:
+
+1. **First priority: Native secrets manager integration**
+   If a resource has the ability to automatically manage a sensitive attribute by
+   storing it in a secrets manager (e.g., AWS Secrets Manager, Azure Key Vault),
+   use that configuration. This is the preferred approach.
+
+   ```hcl
+   # Bad
+   resource "aws_rds_cluster" "example" {
+     cluster_identifier = "example"
+     database_name      = "test"
+     master_username    = "test"
+     master_password    = var.db_master_password
+   }
+
+   # Good, managed by AWS Secrets Manager by default
+   resource "aws_rds_cluster" "test" {
+     cluster_identifier          = "example"
+     database_name               = "test"
+     manage_master_user_password = true
+     master_username             = "test"
+   }
+   ```
+
+2. **Second priority: Write-only attributes with ephemeral resources**
+   If a resource has a write-only attribute but no native secrets manager integration,
+   use an `ephemeral` resource for the sensitive data and pass that to the write-only
+   attribute. Default the write-only version to 1.
+
+   ```hcl
+   # Bad
+   resource "random_password" "password" {
+     length           = 16
+     special          = true
+     override_special = "!#$%&*()-_=+[]{}<>:?"
+   }
+ 
+   resource "vault_kv_secret_v2" "example" {
+     mount               = vault_mount.kvv2.path
+     name                = "secret"
+ 
+     data_json = jsonencode(
+       {
+         password = "${random_password.password.result}",
+       }
+     )
+   }
+ 
+   # Good
+   ephemeral "random_password" "password" {
+     length           = 16
+     special          = true
+     override_special = "!#$%&*()-_=+[]{}<>:?"
+   }
+ 
+   resource "vault_kv_secret_v2" "example" {
+     mount               = vault_mount.kvv2.path
+     name                = "secret"
+ 
+     data_json_wo = jsonencode(
+       {
+         password = "${ephemeral.random_password.password.result}",
+       }
+     )
+     data_json_wo_version = 1
+   }
+   ```
+
+   If you need to retrieve a secret from a secrets manager to pass
+   to a resource, use the `ephemeral` version of the resource to
+   retrieve the secret and pass it to another resource.
+   
+   ```hcl
+   # Good
+   ephemeral "vault_kv_secret_v2" "db_secret" {
+     mount = vault_mount.kvv2.path
+     mount_id = vault_mount.kvv2.id
+     name = vault_kv_secret_v2.db_root.name
+   }
+   
+   resource "vault_database_secret_backend_connection" "postgres" {
+     backend       = vault_mount.db.path
+     name          = "postrgres-db"
+     allowed_roles = ["*"]
+   
+     postgresql {
+       connection_url = "postgresql://{{username}}:{{password}}@localhost:5432/postgres"
+       password_authentication = ""
+       username = "postgres"
+       password_wo = tostring(ephemeral.vault_kv_secret_v2.db_secret.data.password)
+       password_wo_version = 1
+     }
+   }
+   ```
+
+3. **Last resort: Regular resources with warning**
+   Only if neither of the above options are available, use a regular resource
+   and add the warning comment. Do NOT add this warning when using ephemeral resources,
+   as they do not persist sensitive data to state.
+   
+   ```hcl
+   # WARNING: This resource contains a sensitive attribute that will be written as
+   # plaintext in state.
+   ```

--- a/terraform/code-generation/skills/terraform-style-guide/SKILL.md
+++ b/terraform/code-generation/skills/terraform-style-guide/SKILL.md
@@ -222,51 +222,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu" {
 
 ## Security Best Practices
 
-When generating code, apply security hardening:
-
-- Enable encryption at rest by default
-- Configure private networking where applicable
-- Apply principle of least privilege for security groups
-- Enable logging and monitoring
-- Never hardcode credentials or secrets
-- Mark sensitive outputs with `sensitive = true`
-
-### Example: Secure S3 Bucket
-
-```hcl
-resource "aws_s3_bucket" "data" {
-  bucket = "${var.project}-${var.environment}-data"
-  tags   = local.common_tags
-}
-
-resource "aws_s3_bucket_versioning" "data" {
-  bucket = aws_s3_bucket.data.id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
-  bucket = aws_s3_bucket.data.id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm     = "aws:kms"
-      kms_master_key_id = aws_kms_key.s3.arn
-    }
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "data" {
-  bucket = aws_s3_bucket.data.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-```
+Refer to SECURITY.md.
 
 ## Version Pinning
 


### PR DESCRIPTION
This PR adds guidance around use of ephemeral resources and write-only attributes to prevent sensitive data being written to Terraform state.

- As per review by `tessl`, security recommendations have been moved to a separate file due to length.
- Ephemeral resource guidance includes priority order of deciding when to use it.
- A comment is added with a warning if a resource has a sensitive attribute without a write-only argument.
- `tessl skill review` indicates no additional changes required to `SECURITY.md`.