### PR TITLE
feat: add ephemeral resource guidance to terraform-style-guide

### DIFF
--- a/terraform/code-generation/skills/terraform-style-guide/SECURITY.md
+++ b/terraform/code-generation/skills/terraform-style-guide/SECURITY.md
@@ -1,0 +1,164 @@
+---
+name: terraform-style-guide-security
+description: Generate Terraform HCL code following HashiCorp's security practices
+---
+
+# Terraform Style Guide - Security
+
+When generating code, apply security hardening:
+
+- Enable encryption at rest by default
+- Configure private networking where applicable
+- Apply principle of least privilege for security groups
+- Enable logging and monitoring
+- Never hardcode credentials or secrets
+- Mark sensitive outputs with `sensitive = true`
+- Use `ephemeral` resources and write-only attributes
+  for sensitive data when possible
+
+## Example: Secure S3 Bucket
+
+```hcl
+resource "aws_s3_bucket" "data" {
+  bucket = "${var.project}-${var.environment}-data"
+  tags   = local.common_tags
+}
+
+resource "aws_s3_bucket_versioning" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.s3.arn
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "data" {
+  bucket = aws_s3_bucket.data.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+```
+
+## Ephemeral resources
+
+Ephemeral resources prevent sensitive data being stored in state.
+For more information on ephemeral resources, see the
+[Terraform documentation](https://developer.hashicorp.com/terraform/language/block/ephemeral).
+
+Before you generate code for an ephemeral resource, check that the Terraform
+version is greater than or equal to 1.11.0.
+
+Then, follow this priority order for managing sensitive attributes:
+
+1. **First priority: Native secrets manager integration**
+   If a resource has the ability to automatically manage a sensitive attribute by
+   storing it in a secrets manager (e.g., AWS Secrets Manager, Azure Key Vault),
+   use that configuration. This is the preferred approach.
+
+   ```hcl
+   # Bad
+   resource "aws_rds_cluster" "example" {
+     cluster_identifier = "example"
+     database_name      = "test"
+     master_username    = "test"
+     master_password    = var.db_master_password
+   }
+
+   # Good, managed by AWS Secrets Manager by default
+   resource "aws_rds_cluster" "test" {
+     cluster_identifier          = "example"
+     database_name               = "test"
+     manage_master_user_password = true
+     master_username             = "test"
+   }
+   ```
+
+2. **Second priority: Write-only attributes with ephemeral resources**
+   If a resource has a write-only attribute but no native secrets manager integration,
+   use an `ephemeral` resource for the sensitive data and pass that to the write-only
+   attribute. Default the write-only version to 1.
+
+   ```hcl
+   # Bad
+   resource "random_password" "password" {
+     length           = 16
+     special          = true
+     override_special = "!#$%&*()-_=+[]{}<>:?"
+   }
+ 
+   resource "vault_kv_secret_v2" "example" {
+     mount               = vault_mount.kvv2.path
+     name                = "secret"
+ 
+     data_json = jsonencode(
+       {
+         password = "${random_password.password.result}",
+       }
+     )
+   }
+ 
+   # Good
+   ephemeral "random_password" "password" {
+     length           = 16
+     special          = true
+     override_special = "!#$%&*()-_=+[]{}<>:?"
+   }
+ 
+   resource "vault_kv_secret_v2" "example" {
+     mount               = vault_mount.kvv2.path
+     name                = "secret"
+ 
+     data_json_wo = jsonencode(
+       {
+         password = "${ephemeral.random_password.password.result}",
+       }
+     )
+     data_json_wo_version = 1
+   }
+   ```
+
+   If you need to retrieve a secret from a secrets manager to pass
+   to a resource, use the `ephemeral` version of the resource to
+   retrieve the secret and pass it to another resource.
+   
+   ```hcl
+   # Good
+   ephemeral "vault_kv_secret_v2" "db_secret" {
+     mount = vault_mount.kvv2.path
+     mount_id = vault_mount.kvv2.id
+     name = vault_kv_secret_v2.db_root.name
+   }
+   
+   resource "vault_database_secret_backend_connection" "postgres" {
+     backend       = vault_mount.db.path
+     name          = "postrgres-db"
+     allowed_roles = ["*"]
+   
+     postgresql {
+       connection_url = "postgresql://{{username}}:{{password}}@localhost:5432/postgres"
+       password_authentication = ""
+       username = "postgres"
+       password_wo = tostring(ephemeral.vault_kv_secret_v2.db_secret.data.password)
+       password_wo_version = 1
+     }
+   }
+   ```
+
+3. **Last resort: Regular resources**
+   Only use a regular resource that has sensitive data written to state if neither of the above
+   options are available, resource does not offer a write-only attribute or ephemeral resource
+   alternative, or the Terraform version is less than 1.11.0.

--- a/terraform/code-generation/skills/terraform-style-guide/SKILL.md
+++ b/terraform/code-generation/skills/terraform-style-guide/SKILL.md
@@ -222,51 +222,8 @@ resource "aws_cloudwatch_metric_alarm" "cpu" {
 
 ## Security Best Practices
 
-When generating code, apply security hardening:
-
-- Enable encryption at rest by default
-- Configure private networking where applicable
-- Apply principle of least privilege for security groups
-- Enable logging and monitoring
-- Never hardcode credentials or secrets
-- Mark sensitive outputs with `sensitive = true`
-
-### Example: Secure S3 Bucket
-
-```hcl
-resource "aws_s3_bucket" "data" {
-  bucket = "${var.project}-${var.environment}-data"
-  tags   = local.common_tags
-}
-
-resource "aws_s3_bucket_versioning" "data" {
-  bucket = aws_s3_bucket.data.id
-
-  versioning_configuration {
-    status = "Enabled"
-  }
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
-  bucket = aws_s3_bucket.data.id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm     = "aws:kms"
-      kms_master_key_id = aws_kms_key.s3.arn
-    }
-  }
-}
-
-resource "aws_s3_bucket_public_access_block" "data" {
-  bucket = aws_s3_bucket.data.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-```
+Refer to SECURITY.md. It includes guidance on encrypting resources,
+preventing sensitive data in state, and secure configurations.
 
 ## Version Pinning
 


### PR DESCRIPTION
Break out the security guidance into separate file for length.
Guidance includes when to use ephemeral resources and write-only attribute for the style guide.

# Test Output

Matches skill review score before changes. Changes have only been scoped to updating sensitive data guidance.

```bash
$ tessl skill review .

Validation Checks

  ✔ skill_md_line_count - SKILL.md line count is 311 (<= 500)
  ✔ frontmatter_valid - YAML frontmatter is valid
  ✔ name_field - 'name' field is valid: 'terraform-style-guide'
  ✔ description_field - 'description' field is valid (165 chars)
  ✔ compatibility_field - 'compatibility' field not present (optional)
  ✔ allowed_tools_field - 'allowed-tools' field not present (optional)
  ✔ metadata_version - 'metadata' field not present (optional)
  ✔ metadata_field - 'metadata' field not present (optional)
  ✔ license_field - 'license' field not present (optional)
  ✔ frontmatter_unknown_keys - No unknown frontmatter keys found
  ✔ body_present - SKILL.md body is present

Overall: PASSED (0 errors, 0 warnings)

Judge Evaluation

  Description: 75%
    specificity: 2/3 - Names the domain (Terraform HCL) and mentions style conventions and best practices, but doesn't list specific concrete actions like 'create modules, define variables, configure providers, write resource blocks'.
    trigger_term_quality: 2/3 - Includes good terms like 'Terraform', 'HCL', and 'Terraform configurations', but misses common variations users might say such as '.tf files', 'infrastructure as code', 'IaC', 'terraform modules', 'terraform plan', or 'HashiCorp'.
    completeness: 3/3 - Clearly answers both 'what' (generate Terraform HCL code following HashiCorp's style conventions and best practices) and 'when' (Use when writing, reviewing, or generating Terraform configurations) with an explicit 'Use when...' clause.
    distinctiveness_conflict_risk: 3/3 - Terraform HCL is a clear niche with distinct triggers; unlikely to conflict with other skills since it specifically targets Terraform configurations and HashiCorp conventions.

    Assessment: The description is well-structured with a clear 'Use when...' clause and targets a distinct domain. Its main weakness is a lack of specific concrete actions beyond 'generate code' and limited trigger term coverage for common user phrasings around infrastructure-as-code workflows.

    Suggestions:
      - Add more specific concrete actions, e.g., 'create resource blocks, define variables and outputs, configure providers, structure modules'.
      - Expand trigger terms to include common variations like '.tf files', 'infrastructure as code', 'IaC', 'terraform modules', 'terraform providers'.

  Content: 65%
    conciseness: 2/3 - Generally efficient with good use of tables and code examples, but includes some content Claude already knows (version constraint operators are basic Terraform knowledge, and the version control section about .gitignore patterns is standard). Some sections like Provider Configuration repeat patterns already shown earlier.
    actionability: 3/3 - Provides fully executable HCL code examples throughout, with concrete good/bad comparisons, specific file organization, and copy-paste ready configurations. Every section includes real, runnable code rather than pseudocode or abstract descriptions.
    workflow_clarity: 2/3 - The 'Code Generation Strategy' provides a clear sequence, and the validation tools section mentions fmt/validate, but there's no explicit feedback loop (validate -> fix -> retry) for the code generation workflow. The checklist at the end is helpful but the connection between generation steps and validation checkpoints is implicit rather than explicit.
    progressive_disclosure: 2/3 - References SECURITY.md appropriately for security best practices, but the main file is quite long (~200 lines of content) with sections like version constraint operators and provider configuration that could be split into reference files. The structure is well-organized with clear headers, but could benefit from more aggressive splitting.

    Assessment: This is a solid, actionable Terraform style guide with excellent concrete examples and good/bad comparisons throughout. Its main weaknesses are moderate verbosity (some sections cover knowledge Claude already has) and a lack of explicit validation feedback loops in the workflow. The content would benefit from trimming well-known concepts and linking out to supplementary files for detailed reference material.

    Suggestions:
      - Remove or significantly trim sections covering basic Terraform knowledge Claude already has, such as version constraint operators and .gitignore patterns for Terraform
      - Add an explicit feedback loop to the Code Generation Strategy: after generating code, run terraform fmt and terraform validate, fix any issues, and re-validate before proceeding
      - Move detailed reference content (version pinning operators, provider configuration patterns, dynamic resource creation examples) into a separate REFERENCE.md to keep the main skill lean

Review Score: 76%

⚠ Skill is valid but could be improved.
```