### PR TITLE
fix(ci): escape backticks in tessl-skill-review workflow

### DIFF
--- a/.github/workflows/tessl-skill-review.yml
+++ b/.github/workflows/tessl-skill-review.yml
@@ -202,7 +202,7 @@ jobs:
             fi
 
             DIR_DISPLAY=$(echo "$dir" | tr '|' '/')
-            TABLE="${TABLE}\\n| \\`${DIR_DISPLAY}\\` | ${STATUS} | ${AVG_SCORE}% | ${CHANGE} |"
+            TABLE="${TABLE}\\n| \`${DIR_DISPLAY}\` | ${STATUS} | ${AVG_SCORE}% | ${CHANGE} |"
 
             # Calculate dimension scores for cache and details
             DESC_SCORE=$(echo "$JSON" | jq -r '
@@ -253,7 +253,7 @@ jobs:
               DETAILS="${DETAILS}---\\n\\n"
             fi
 
-            DETAILS="${DETAILS}\\`\\`\\`\\n${DESC_EVAL}\\n\\n${CONTENT_EVAL}\\n\\`\\`\\`\\n"
+            DETAILS="${DETAILS}\`\`\`\\n${DESC_EVAL}\\n\\n${CONTENT_EVAL}\\n\`\`\`\\n"
 
             if [[ -n "$SUGGESTIONS" ]]; then
               DETAILS="${DETAILS}\\n**Suggestions:**\\n\\n${SUGGESTIONS}\\n"


### PR DESCRIPTION
## Summary

The `Tessl Skill Review` workflow has been failing on every PR that changes a `SKILL.md` since PR #50 landed. The root cause is a shell-escape bug on two lines of `.github/workflows/tessl-skill-review.yml`.

On line 205 (and similarly line 256):

```bash
TABLE="${TABLE}\\n| \\`${DIR_DISPLAY}\\` | ${STATUS} | ${AVG_SCORE}% | ${CHANGE} |"
```

Inside a bash double-quoted string, the sequence `\\` ` ` parses as literal `\` followed by an **unescaped** backtick, which opens a command substitution. Bash then executes the skill path as a command, e.g.:

```
line 99: terraform/code-generation/skills/terraform-search-import\: No such file or directory
##[error]Process completed with exit code 127.
```

This is reproducible in every recent failing run (e.g. [24563203625](https://github.com/hashicorp/agent-skills/actions/runs/24563203625), [24512865000](https://github.com/hashicorp/agent-skills/actions/runs/24512865000), [24415817440](https://github.com/hashicorp/agent-skills/actions/runs/24415817440)). The only recent "success" ([24321383215](https://github.com/hashicorp/agent-skills/actions/runs/24321383215)) is a run where `Detect changed skills` found nothing and the review step was skipped.

## Fix

Change 
```
`\\` ` ` 
```
to 
```
`\` ` `
``` 
(single backslash + backtick) so the backtick is treated as a literal character inside the double-quoted string. Two lines:

- `TABLE=` table-row assignment
- `DETAILS=` code-fence wrapper

## Test plan

- [x] Local bash repro confirmed the original pattern triggers command substitution; the new pattern produces a plain string.
- [x] End-to-end run on my fork against all 16 skills in the repo via `workflow_dispatch`: [run 24574354194](https://github.com/robw-tessl/agent-skills/actions/runs/24574354194) — green, all skills reviewed, 16 cache entries written.