### PR TITLE
Assign codeowners for terraform and packer skill directories

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,14 @@
 # Default owner
 * @hashicorp/team-proj-mcp-servers
+
+# Packer skills
+/packer/ @raunaq-iac
+
+# Terraform code generation
+/terraform/code-generation/ @xiehan @NicoletaPopoviciu
+
+# Terraform module generation
+/terraform/module-generation/ @xiehan @NicoletaPopoviciu
+
+# Terraform provider development
+/terraform/provider-development/ @Hashtb


### PR DESCRIPTION
## Summary

- Assigns `@raunaq-iac` as codeowner for `/packer/`
- Assigns `@xiehan` and `@NicoletaPopoviciu` as codeowners for `/terraform/code-generation/` and `/terraform/module-generation/`
- Assigns `@Hashtb` as codeowner for `/terraform/provider-development/`