### PR TITLE
fix(ci): evaluate jq interpolations in skill-review detailed output

### DIFF
--- a/.github/workflows/tessl-skill-review.yml
+++ b/.github/workflows/tessl-skill-review.yml
@@ -225,13 +225,13 @@ jobs:
             # --- Extract detailed review for collapsible section ---
             DESC_EVAL=$(echo "$JSON" | jq -r '.descriptionJudge.evaluation |
               "  Description: " + ((.scores | to_entries | map(.value.score) | add) * 100 / ((.scores | length) * 3) | round | tostring) + "%\\n" +
-              (.scores | to_entries | map("    \\(.key): \\(.value.score)/3 - \\(.value.reasoning)") | join("\\n")) + "\\n\\n" +
+              (.scores | to_entries | map("    \(.key): \(.value.score)/3 - \(.value.reasoning)") | join("\\n")) + "\\n\\n" +
               "    Assessment: " + .overall_assessment
             ')
 
             CONTENT_EVAL=$(echo "$JSON" | jq -r '.contentJudge.evaluation |
               "  Content: " + ((.scores | to_entries | map(.value.score) | add) * 100 / ((.scores | length) * 3) | round | tostring) + "%\\n" +
-              (.scores | to_entries | map("    \\(.key): \\(.value.score)/3 - \\(.value.reasoning)") | join("\\n")) + "\\n\\n" +
+              (.scores | to_entries | map("    \(.key): \(.value.score)/3 - \(.value.reasoning)") | join("\\n")) + "\\n\\n" +
               "    Assessment: " + .overall_assessment
             ')
 


### PR DESCRIPTION
## Summary

The **Detailed Review** section of every `Tessl Skill Review` PR comment renders per-criterion lines as literal text instead of real scores — e.g. [PR #66](https://github.com/hashicorp/agent-skills/pull/66#issuecomment-4270338501), [PR #64](https://github.com/hashicorp/agent-skills/pull/64#issuecomment-4270311516):

```
    \(.key): \(.value.score)/3 - \(.value.reasoning)
```

## Cause and fix

Lines 228 and 234 of `.github/workflows/tessl-skill-review.yml` over-escape jq interpolations. The jq program is single-quoted in bash, so jq sees `\\(.key)` — `\\` is an escaped backslash, leaving a literal `\` before `(.key)` that jq prints verbatim instead of interpolating.

```diff
- map("    \\(.key): \\(.value.score)/3 - \\(.value.reasoning)")
+ map("    \(.key): \(.value.score)/3 - \(.value.reasoning)")
```

Surrounding `\\n` sequences are intentionally kept — they're consumed downstream by `printf '%b'`.

## Test plan

Reproduced the upstream workflow verbatim (real `tessl skill review --json` against a sample skill, no API key) and confirmed:

- **Before**: `\(.key): \(.value.score)/3 - \(.value.reasoning)`
- **After**: `specificity: 2/3 - It mentions 'print a hello world greeting' ...`

Table, score column, suggestions, and `<details>` collapsing render identically before/after. Does not touch the `TABLE=` / `DETAILS=` lines fixed in #67.