### PR TITLE
fix: update terraform docs for provider-docs and provider-test-patterns skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,9 @@ agent-skills/
 │           ├── new-terraform-provider/
 │           ├── run-acceptance-tests/
 │           ├── provider-actions/
-│           └── provider-resources/
+│           ├── provider-docs/
+│           ├── provider-resources/
+│           └── provider-test-patterns/
 ├── packer/
 │   ├── builders/
 │   │   ├── .claude-plugin/plugin.json
@@ -112,7 +114,9 @@ npx skills add hashicorp/agent-skills/terraform/module-generation/skills/terrafo
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/new-terraform-provider
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/run-acceptance-tests
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-actions
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-docs
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-resources
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-test-patterns
 
 # Packer builder skills
 npx skills add hashicorp/agent-skills/packer/builders/skills/aws-ami-builder
@@ -171,7 +175,9 @@ Skills for developing Terraform providers:
 | `new-terraform-provider` | Scaffold a new Terraform provider |
 | `run-acceptance-tests` | Run and debug provider acceptance tests |
 | `provider-actions` | Implement provider actions (lifecycle operations) |
+| `provider-docs` | Provider documentation with tfplugindocs for the Terraform Registry |
 | `provider-resources` | Implement resources and data sources |
+| `provider-test-patterns` | Acceptance test patterns for terraform-plugin-testing |
 
 ### packer-builders
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the HashiCorp Agent Skills.
 ## Unreleased
 
 ### Added
+- `provider-test-patterns` skill for acceptance test patterns with terraform-plugin-testing
+- `provider-docs` skill for Terraform Registry provider documentation with tfplugindocs
 - `terraform-search-import` skill for discovering existing resources with Terraform Search and bulk import
 
 ## 0.1.0

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -33,6 +33,7 @@ Skills for developing Terraform providers.
 | new-terraform-provider | Scaffold a new Terraform provider |
 | run-acceptance-tests   | Run and debug provider acceptance tests |
 | provider-actions       | Implement provider actions (lifecycle operations) |
+| provider-docs          | Provider documentation with tfplugindocs for the Terraform Registry |
 | provider-resources     | Implement resources and data sources |
 | provider-test-patterns | Acceptance test patterns for terraform-plugin-testing |
 
@@ -65,6 +66,7 @@ npx skills add hashicorp/agent-skills/terraform/module-generation/skills/terrafo
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/new-terraform-provider
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/run-acceptance-tests
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-actions
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-docs
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-resources
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-test-patterns
 ```
@@ -99,6 +101,7 @@ terraform/
     └── skills/
         ├── new-terraform-provider/
         ├── provider-actions/
+        ├── provider-docs/
         ├── provider-resources/
         ├── run-acceptance-tests/
         └── provider-test-patterns/


### PR DESCRIPTION
The repo listings drifted out of date as skills were added:

- `terraform/README.md` — `provider-docs` was missing from the
  terraform-provider-development table, the `npx skills add` list, and the structure
  tree
- `AGENTS.md` — both `provider-docs` and `provider-test-patterns` were missing from
  the structure tree, the plugin-contents table, and the `npx skills add` list
- `CHANGELOG.md` — neither skill had an entry; both added under Unreleased/Added
  (the 0.1.0 "9 total skills" line was accurate at the time and is left alone)

Docs-only change; no skill content touched. Deliberately does **not** mention the new
`provider-configuration` skill — its own PR self-registers, keeping both PRs correct
in any merge order (expect a trivial adjacent-line conflict in these three files with
that PR; both-sides-keep resolves it).

**Verification:** `scripts/validate-structure.sh` passes.
