### PR TITLE
fix(ci): use TESSL_TOKEN auth, surface CLI errors, skip review on fork PRs

### DIFF
--- a/.github/workflows/tessl-skill-review.yml
+++ b/.github/workflows/tessl-skill-review.yml
@@ -34,7 +34,14 @@ jobs:
           node-version: '20'
 
       - name: Install Tessl CLI
-        run: npm install -g @tessl/cli
+        # Pinned: an unpinned install silently picked up the release that
+        # renamed the auth env var (TESSL_API_KEY -> TESSL_TOKEN), breaking
+        # every run from 2026-06-24 onward. Note `tessl skill review` is
+        # deprecated and scheduled for removal after July 2026 — migrate to
+        # `tessl review run <path> --workspace <ws> --json` before bumping
+        # past a version that removes it:
+        # https://docs.tessl.io/improving-your-skills/migrate-from-skill-review
+        run: npm install -g @tessl/cli@0.90.0
 
       - name: Detect changed skills
         id: detect
@@ -104,8 +111,22 @@ jobs:
         id: review
         env:
           SKILLS: ${{ steps.detect.outputs.skills }}
-          TESSL_API_KEY: ${{ secrets.TESSL_API_KEY }}
+          # Tessl CLI >= 0.86 authenticates via TESSL_TOKEN and ignores the
+          # old TESSL_API_KEY variable. Fall back to the legacy secret name
+          # so existing repository configuration keeps working if the token
+          # value is still valid.
+          TESSL_TOKEN: ${{ secrets.TESSL_TOKEN || secrets.TESSL_API_KEY }}
         run: |
+          # GitHub withholds repository secrets from pull requests opened
+          # from forks; without a token the CLI can only fail. Skip with a
+          # notice instead of failing the check — structural validation
+          # still runs in the Validate Structure workflow.
+          if [[ -z "${TESSL_TOKEN}" ]]; then
+            echo "::notice::TESSL_TOKEN is not available (expected for pull requests from forks). Skipping Tessl skill review."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           FAILED=0
           TABLE="| Skill | Status | Review Score | Change |"
           TABLE="${TABLE}\\n|-------|--------|--------------|--------|"
@@ -119,8 +140,19 @@ jobs:
             [[ -z "$dir" ]] && continue
             echo "::group::Reviewing $dir"
 
-            # Run review with --json flag
-            JSON_OUTPUT=$(tessl skill review --json "$dir" 2>&1)
+            # Run review with --json flag. Guard the command substitution:
+            # this step runs under `bash -e`, so an unguarded failure would
+            # kill the script before the CLI's error output is echoed —
+            # exactly how the TESSL_API_KEY rename went undiagnosed.
+            if ! JSON_OUTPUT=$(tessl skill review --json "$dir" 2>&1); then
+              echo "$JSON_OUTPUT"
+              echo "::endgroup::"
+              echo "::error::tessl skill review failed for ${dir}"
+              DIR_DISPLAY=$(echo "$dir" | tr '|' '/')
+              TABLE="${TABLE}\\n| \`${DIR_DISPLAY}\` | ⚠️ REVIEW ERROR | — | — |"
+              FAILED=1
+              continue
+            fi
             echo "$JSON_OUTPUT"
             echo "::endgroup::"
 
@@ -320,7 +352,7 @@ jobs:
           fi
 
       - name: Update review cache
-        if: always() && steps.review.outcome != 'skipped'
+        if: always() && steps.review.outcome != 'skipped' && steps.review.outputs.skipped != 'true'
         id: update-cache
         run: |
           CACHE_FILE=".github/.tessl/skill-review-cache.json"
@@ -389,7 +421,7 @@ jobs:
           path: .github/.tessl/skill-review-cache.json
 
       - name: Upload cache entries artifact
-        if: always() && steps.review.outcome != 'skipped'
+        if: always() && steps.review.outcome != 'skipped' && steps.review.outputs.skipped != 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cache-entries
@@ -400,6 +432,7 @@ jobs:
         if: >-
           github.event_name == 'pull_request'
           && steps.detect.outputs.skills != ''
+          && steps.review.outputs.skipped != 'true'
           && (steps.review.outcome == 'success' || steps.review.outputs.comment != '')
         env:
           COMMENT_BODY: ${{ steps.review.outputs.comment }}
@@ -413,6 +446,7 @@ jobs:
         if: >-
           github.event_name == 'pull_request'
           && steps.detect.outputs.skills != ''
+          && steps.review.outputs.skipped != 'true'
           && (steps.review.outcome == 'success' || steps.review.outputs.comment != '')
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:


### PR DESCRIPTION
The Tessl Skill Review workflow has failed on **every run since 2026-06-24** — pushes to `main` and in-repo PRs included, not just fork PRs. This PR fixes the root cause and two compounding problems.

## Root cause (reproduced locally)

The workflow installs the CLI unpinned (`npm install -g @tessl/cli`), and a release in the 2026-06-22/23 window (0.86.0/0.87.0) **renamed the CI auth variable from `TESSL_API_KEY` to `TESSL_TOKEN`** (per the [migration guide](https://docs.tessl.io/improving-your-skills/migrate-from-skill-review), which documents `TESSL_TOKEN` for CI). The workflow still exports `TESSL_API_KEY`, which current CLI versions ignore entirely.

Verified with `@tessl/cli@0.90.0`:

- `TESSL_API_KEY=<value> tessl whoami` → "You are not logged in" (variable ignored)
- `TESSL_TOKEN=<fake> tessl whoami` → `401 Unauthorized` (variable read, sent to the API)
- `tessl skill review --json <dir>` with no usable token → "Skill review requires you to be logged in" + exit 1

Timeline evidence: last successful run 2026-05-21; first failure 2026-06-24; the workflow file itself unchanged since 2026-05-11; the run on `main` at 2026-07-09 shows `TESSL_API_KEY: ***` (secret present) yet fails identically.

## Why it went undiagnosed for three weeks

The review step runs under `bash -e`, and the CLI call is a bare command substitution:

```bash
JSON_OUTPUT=$(tessl skill review --json "$dir" 2>&1)
echo "$JSON_OUTPUT"
```

When `tessl` exits non-zero, `-e` kills the script **before the echo**, so every failed run's log shows a group opening and an immediate `Process completed with exit code 1` — with the CLI's actual error message swallowed.

## Changes

1. **Auth**: export `TESSL_TOKEN: ${{ secrets.TESSL_TOKEN || secrets.TESSL_API_KEY }}` — works immediately if the existing secret's value is still a valid token, and lets you migrate the secret name cleanly. **Maintainer action**: verify the stored value still authenticates (`TESSL_TOKEN=<value> tessl whoami`); mint a fresh token if not.
2. **Pin the CLI** to `@tessl/cli@0.90.0` so upstream releases can't silently break CI again.
3. **Surface CLI errors**: guard the command substitution (`if ! JSON_OUTPUT=$(...)`) so a failing review prints its output, marks the skill `⚠️ REVIEW ERROR` in the summary table, and continues to the remaining skills — the job still fails, but visibly.
4. **Fork-PR guard**: GitHub withholds repository secrets from fork-triggered `pull_request` runs, so external contributions can never have a token. With an empty `TESSL_TOKEN` the step now emits a notice and exits 0 (the score is documented as "informational — not used for pass/fail gating"; structural validation still gates via the Validate Structure workflow). Downstream cache/comment steps are gated on the same condition so a skip produces no empty artifacts or blank PR comments.

## Follow-up (not in this PR — needs maintainer input)

`tessl skill review` is deprecated and scheduled for **removal after July 2026**. The replacement is `tessl review run <path> --workspace <workspace> --json [--threshold N]` — workspace is required in non-interactive mode, and the JSON output shape (which this workflow's `jq` parsing depends on) needs verification against the new command. A comment in the install step records this.

## Verification

- YAML parses (`yq`); every `run:` block passes `bash -n`
- Error-surfacing pattern verified under `bash -e` with a fake token: the CLI's `401 Unauthorized` output is captured, printed, and the loop continues
- The fork-PR skip path will demonstrate itself on this PR's own check run
