### PR TITLE
feat: add provider-framework-migration skill for SDKv2 to Framework migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ agent-skills/
 │           ├── new-terraform-provider/
 │           ├── run-acceptance-tests/
 │           ├── provider-actions/
+│           ├── provider-framework-migration/
 │           └── provider-resources/
 ├── packer/
 │   ├── builders/
@@ -112,6 +113,7 @@ npx skills add hashicorp/agent-skills/terraform/module-generation/skills/terrafo
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/new-terraform-provider
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/run-acceptance-tests
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-actions
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-framework-migration
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-resources
 
 # Packer builder skills
@@ -171,6 +173,7 @@ Skills for developing Terraform providers:
 | `new-terraform-provider` | Scaffold a new Terraform provider |
 | `run-acceptance-tests` | Run and debug provider acceptance tests |
 | `provider-actions` | Implement provider actions (lifecycle operations) |
+| `provider-framework-migration` | Migrate SDKv2 resources to the Plugin Framework |
 | `provider-resources` | Implement resources and data sources |
 
 ### packer-builders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the HashiCorp Agent Skills.
 ## Unreleased
 
 ### Added
+- `provider-framework-migration` skill for migrating SDKv2 resources to the Plugin Framework
 - `terraform-search-import` skill for discovering existing resources with Terraform Search and bulk import
 
 ## 0.1.0

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -33,6 +33,7 @@ Skills for developing Terraform providers.
 | new-terraform-provider | Scaffold a new Terraform provider |
 | run-acceptance-tests   | Run and debug provider acceptance tests |
 | provider-actions       | Implement provider actions (lifecycle operations) |
+| provider-framework-migration | Migrate SDKv2 resources to the Plugin Framework |
 | provider-resources     | Implement resources and data sources |
 | provider-test-patterns | Acceptance test patterns for terraform-plugin-testing |
 
@@ -65,6 +66,7 @@ npx skills add hashicorp/agent-skills/terraform/module-generation/skills/terrafo
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/new-terraform-provider
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/run-acceptance-tests
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-actions
+npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-framework-migration
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-resources
 npx skills add hashicorp/agent-skills/terraform/provider-development/skills/provider-test-patterns
 ```
@@ -99,6 +101,7 @@ terraform/
     └── skills/
         ├── new-terraform-provider/
         ├── provider-actions/
+        ├── provider-framework-migration/
         ├── provider-resources/
         ├── run-acceptance-tests/
         └── provider-test-patterns/

--- a/terraform/provider-development/skills/provider-framework-migration/SKILL.md
+++ b/terraform/provider-development/skills/provider-framework-migration/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: provider-framework-migration
+description: >-
+  Migrate Terraform provider resources and data sources from Plugin SDKv2 to
+  the Plugin Framework: muxing both plugins in one provider
+  (terraform-plugin-mux, tf5to6server), per-resource migration workflow,
+  SDKv2-to-Framework schema mapping (ForceNew, ValidateFunc,
+  DiffSuppressFunc, Default, Timeouts, blocks), null-vs-zero-value
+  behavioral traps, and state-compatibility verification. Use when
+  converting or translating SDKv2 resources to the Framework, setting up a
+  muxed provider server, deciding whether a resource should be migrated at
+  all, or debugging plan diffs and state errors that appeared after a
+  migration.
+license: MPL-2.0
+metadata:
+  copyright: Copyright IBM Corp. 2026
+  version: "0.0.1"
+---
+
+# Migrating from Plugin SDKv2 to the Plugin Framework
+
+The Plugin Framework is required for net-new resources and data sources;
+SDKv2 is maintenance-only. Migration is **per-resource and incremental**: a
+muxed provider serves SDKv2 and Framework implementations side by side, so
+you never need a big-bang rewrite. This skill covers the mux setup, the
+per-resource workflow, and the behavioral traps that turn a mechanical
+translation into a silent breaking change.
+
+**Reference** (load when needed):
+- `references/schema-mapping.md` — the full SDKv2 → Framework translation
+  table with code pairs
+
+Official guide: [Framework migration](https://developer.hashicorp.com/terraform/plugin/framework/migrating).
+
+## Decide Whether to Migrate at All
+
+Migration has real risk and little user-visible payoff, so triage first:
+
+- **Do not migrate complex or heavily-used resources** without a driving
+  need (a Framework-only feature, a bug that SDKv2 cannot fix). The two
+  SDKs differ behaviorally — most importantly around null versus zero
+  values — and those differences surface as breaking changes for existing
+  users. This is the standing policy in large providers like
+  terraform-provider-aws.
+- **Simple resources migrate safely**: flat schemas, no `DiffSuppressFunc`,
+  no `CustomizeDiff`, no `StateFunc`, no complex nested blocks.
+- New capabilities never require migrating old code — mux and write the new
+  resource in the Framework alongside the old ones.
+
+To tell what mode a provider is in, check `go.mod`: `terraform-plugin-mux`
+present means it already serves both; only `terraform-plugin-sdk/v2` means
+SDKv2-only (mux setup is your first step); only
+`terraform-plugin-framework` means the migration is done.
+
+## Step 1: Mux the Provider
+
+Combine both plugin servers in `main.go`. Serving protocol version 6
+requires upgrading the SDKv2 server with `tf5to6server` (protocol 6 needs
+Terraform CLI >= 1.0; if you must support 0.12+, mux at protocol 5 with
+`tf6to5server`/`tf5muxserver` instead — but the Framework provider then
+cannot use protocol-6-only features like nested attributes):
+
+```go
+package main
+
+import (
+    "context"
+    "flag"
+    "log"
+
+    "github.com/hashicorp/terraform-plugin-framework/providerserver"
+    "github.com/hashicorp/terraform-plugin-go/tfprotov6"
+    "github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+    "github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+    "github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+
+    "example.org/terraform-provider-examplecloud/internal/provider"
+    sdkprovider "example.org/terraform-provider-examplecloud/internal/sdkprovider"
+)
+
+func main() {
+    var debug bool
+    flag.BoolVar(&debug, "debug", false, "run with support for debuggers")
+    flag.Parse()
+
+    ctx := context.Background()
+
+    upgradedSDKServer, err := tf5to6server.UpgradeServer(
+        ctx,
+        sdkprovider.Provider().GRPCProvider,
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    providers := []func() tfprotov6.ProviderServer{
+        providerserver.NewProtocol6(provider.New(version)()),
+        func() tfprotov6.ProviderServer { return upgradedSDKServer },
+    }
+
+    muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    var serveOpts []tf6server.ServeOpt
+    if debug {
+        serveOpts = append(serveOpts, tf6server.WithManagedDebug())
+    }
+
+    err = tf6server.Serve("registry.terraform.io/example/examplecloud",
+        muxServer.ProviderServer, serveOpts...)
+    if err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+Mux requirements that bite in practice:
+
+- **Provider schemas must match exactly** across both plugins — same
+  provider-level attributes, same types, same descriptions. Keep one source
+  of truth for the provider configuration and mirror it.
+- **Each resource and data source may exist in only one** of the two
+  plugins. Migration's final step is deleting the SDKv2 registration.
+- If publishing to the Registry with protocol 6, set
+  `"metadata": {"protocol_versions": ["6.0"]}` in
+  `terraform-registry-manifest.json`.
+
+## Step 2: Baseline Before You Touch Anything
+
+The migrated resource must be indistinguishable to users. Prove it with
+tests that exist *before* the migration:
+
+1. Ensure the resource has passing acceptance coverage: `_basic` with an
+   import step (`ImportStateVerify: true`), `_disappears`, and per-attribute
+   update tests. If coverage is missing, write it against the SDKv2
+   implementation first — these tests are the migration's acceptance
+   criteria and must pass **unchanged** afterward.
+2. Note behaviors tests don't capture: attribute defaults, what happens
+   when optional attributes are omitted (null vs `""`/`0`/`false` is about
+   to matter), and any `DiffSuppressFunc`/`StateFunc` normalization.
+
+## Step 3: Port the Resource
+
+Translate schema and CRUD using the mapping table in
+`references/schema-mapping.md`. The rules that prevent breaking changes:
+
+- **Blocks stay blocks.** An SDKv2 `Elem: &schema.Resource{...}` written as
+  `block { ... }` syntax in user configs must become a Framework **Block**
+  (`schema.ListNestedBlock`/`SetNestedBlock`) — converting it to a nested
+  *attribute* changes the HCL syntax users must write, which is a breaking
+  change. Nested attributes are for new schema only.
+- **Null is not zero.** SDKv2 `d.Get("name")` returned `""` for unset;
+  the Framework model gives you `types.String` that distinguishes null,
+  unknown, and `""`. Everywhere the old code checked `== ""` or relied on
+  `GetOk`, decide explicitly what null means, and make sure you send the
+  API the same thing SDKv2 sent (usually: omit the field when null).
+- **Keep the `id` attribute.** Net-new Framework resources may omit a
+  redundant `id`, but a *migrated* resource must keep its exact schema —
+  removing or renaming attributes breaks existing state and configs.
+- **State must round-trip.** The Framework reads the state SDKv2 wrote. If
+  every attribute keeps its name and type, no state upgrade is needed. If
+  the old schema stored a value the new types package normalizes
+  differently, you need a `StateUpgrader` — treat that as a signal the
+  resource may be in the do-not-migrate bucket.
+
+## Step 4: Move the Registration
+
+Register the resource in the Framework provider's `Resources()` and delete
+it from the SDKv2 provider's `ResourcesMap` in the same commit — mux errors
+on duplicates.
+
+## Step 5: Verify
+
+1. The pre-existing acceptance tests pass **without modification** —
+   especially `ImportStateVerify`, which diffs imported state against
+   stored state and catches most null-vs-zero regressions.
+2. Add a state-compatibility step: apply a config with the last released
+   (SDKv2) provider version, then plan with the migrated build — the plan
+   must be empty. In `terraform-plugin-testing` this is a two-step test
+   using `ExternalProviders` for the old version, then
+   `ProtoV6ProviderFactories` with `ConfigPlanChecks` asserting an empty
+   plan. The `provider-test-patterns` skill (if available) documents the
+   pattern.
+3. `terraform plan` against a real pre-migration state file shows no diff.
+
+## Checklist
+
+- [ ] Resource is simple enough to migrate (no complex diff customization), or there's a driving need
+- [ ] Mux serves both plugins; provider-level schemas identical in both
+- [ ] Acceptance tests existed before migration and pass unchanged after
+- [ ] Blocks remained blocks; attribute names and types unchanged; `id` kept
+- [ ] Null/omitted semantics preserved (API receives what SDKv2 sent)
+- [ ] SDKv2 registration removed in the same change
+- [ ] Empty-plan verified against state written by the previous release
+- [ ] Changelog entry added, if the repo tracks release notes
+
+## Related Skills
+
+Use the `provider-resources` skill (if available) for Framework CRUD,
+finder, and waiter patterns in the ported code, and `provider-test-patterns`
+for the regression and version-upgrade test patterns.

--- a/terraform/provider-development/skills/provider-framework-migration/references/schema-mapping.md
+++ b/terraform/provider-development/skills/provider-framework-migration/references/schema-mapping.md
@@ -1,0 +1,102 @@
+# SDKv2 → Plugin Framework Translation Reference
+
+Mechanical mappings for porting a resource. Every row preserves the user's
+configuration syntax and state layout — the invariant of a safe migration.
+
+## Schema: types
+
+| SDKv2 | Framework |
+|---|---|
+| `Type: schema.TypeString` | `schema.StringAttribute` |
+| `Type: schema.TypeBool` | `schema.BoolAttribute` |
+| `Type: schema.TypeInt` | `schema.Int64Attribute` |
+| `Type: schema.TypeFloat` | `schema.Float64Attribute` |
+| `Type: schema.TypeList, Elem: &schema.Schema{Type: schema.TypeString}` | `schema.ListAttribute{ElementType: types.StringType}` |
+| `Type: schema.TypeSet, Elem: &schema.Schema{...}` | `schema.SetAttribute{ElementType: ...}` |
+| `Type: schema.TypeMap, Elem: &schema.Schema{...}` | `schema.MapAttribute{ElementType: ...}` |
+| `Type: schema.TypeList, Elem: &schema.Resource{...}` (block syntax in configs) | `schema.ListNestedBlock` under `Blocks:` — **not** a nested attribute (attribute syntax would break existing configs) |
+| `Type: schema.TypeSet, Elem: &schema.Resource{...}` | `schema.SetNestedBlock` under `Blocks:` |
+| `MaxItems: 1` block used as a pseudo-object | `ListNestedBlock` + `listvalidator.SizeAtMost(1)` for migrations; `SingleNestedAttribute` only for net-new schema |
+
+## Schema: behaviors
+
+| SDKv2 | Framework |
+|---|---|
+| `Required: true` / `Optional: true` / `Computed: true` | Same fields, same meanings |
+| `ForceNew: true` | `PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()}` |
+| `Default: "foo"` | `Default: stringdefault.StaticString("foo")` (from `resource/schema/stringdefault`; requires `Computed: true` alongside `Optional`) |
+| `ValidateFunc` / `ValidateDiagFunc` | `Validators: []validator.String{...}` (from `terraform-plugin-framework-validators`) |
+| `ConflictsWith` / `ExactlyOneOf` / `AtLeastOneOf` / `RequiredWith` | `stringvalidator.ConflictsWith(path.Expressions...)`, `ExactlyOneOf(...)`, `AtLeastOneOf(...)`, `AlsoRequires(...)` |
+| `Sensitive: true` | Same field |
+| `Deprecated: "..."` | `DeprecationMessage: "..."` |
+| `Description` | `Description` / `MarkdownDescription` |
+| `DiffSuppressFunc` | No direct equivalent. Use a custom type with semantic equality (preferred; e.g. case-insensitive or JSON-normalized string types) or a plan modifier. If the suppression logic is intricate, reconsider migrating this resource |
+| `StateFunc` | No equivalent — normalize in Create/Read before setting state, or use a custom type |
+| `CustomizeDiff` | Resource-level plan modification: `ResourceWithModifyPlan.ModifyPlan`, or per-attribute plan modifiers |
+| `Timeouts` in schema | `timeouts` block via `terraform-plugin-framework-timeouts`; read with `data.Timeouts.Create(ctx, defaultTimeout)` |
+
+## Resource shape
+
+| SDKv2 | Framework |
+|---|---|
+| `func resourceWidget() *schema.Resource` returning struct of funcs | Struct implementing `resource.Resource` (+ `ResourceWithConfigure`, `ResourceWithImportState`) |
+| `CreateWithoutTimeout: resourceWidgetCreate` | `func (r *widgetResource) Create(ctx, req resource.CreateRequest, resp *resource.CreateResponse)` |
+| `meta.(*Client)` in every CRUD func | Client stored once by `Configure(req.ProviderData)` |
+| `Importer: &schema.ResourceImporter{StateContext: schema.ImportStatePassthroughContext}` | `func (r *widgetResource) ImportState(...)` calling `resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)` |
+| Registration in `ResourcesMap: map[string]*schema.Resource` | Constructor listed in the provider's `Resources() []func() resource.Resource` |
+
+## Data access inside CRUD
+
+| SDKv2 | Framework |
+|---|---|
+| `d.Get("name").(string)` | Typed model: `data.Name.ValueString()` after `req.Plan.Get(ctx, &data)` |
+| `d.GetOk("name")` | `!data.Name.IsNull()` — and decide unknown handling explicitly (`IsUnknown()`) |
+| `d.Set("name", v)` | Assign model field (`data.Name = types.StringPointerValue(v)`), then `resp.State.Set(ctx, &data)` |
+| `d.SetId(id)` | Set the `id` model field like any attribute |
+| `d.SetId("")` in Read (gone) | `resp.State.RemoveResource(ctx)` |
+| `d.Id()` | `data.ID.ValueString()` from `req.State.Get` |
+| `d.HasChange("field")` | Compare plan vs state models: `!plan.Field.Equal(state.Field)` |
+| `d.IsNewResource()` | Does not exist — Create simply *is* the new-resource path; post-create read-retry logic moves into Create |
+| `diag.Diagnostics` returns | `resp.Diagnostics.AddError/AddWarning/Append` |
+
+## The null/zero trap (the migration's main behavioral risk)
+
+SDKv2 collapses "not set" into Go zero values: `d.Get` on an unset string
+returns `""`, an unset int `0`, an unset bool `false`. The Framework keeps
+null, unknown, and zero distinct. Consequences:
+
+```go
+// SDKv2 — unset and "" are the same thing:
+if v, ok := d.GetOk("description"); ok {
+    input.Description = aws.String(v.(string))
+}
+
+// Framework — express the same "omit when not set" explicitly:
+if !data.Description.IsNull() {
+    input.Description = data.Description.ValueStringPointer()
+}
+```
+
+Audit every attribute for three cases: user set a value, user set the zero
+value (`""`, `0`, `false` — SDKv2 could not tell this apart from unset;
+users may depend on either interpretation), and user omitted it. The API
+must receive exactly what the SDKv2 version sent in each case, or existing
+configurations change behavior. `ImportStateVerify` and empty-plan upgrade
+tests catch most, not all, of these — grep for `GetOk` and zero-value
+comparisons and reason through each.
+
+## What does not change
+
+- `retry.StateChangeConf` waiters and `retry.NotFoundError` finders — the
+  `helper/retry` package works from Framework code; port them untouched.
+- Acceptance tests — `terraform-plugin-testing` runs against the muxed
+  provider; existing tests must pass unchanged (switch factories to
+  `ProtoV6ProviderFactories` serving the muxed server).
+- API client code, expand/flatten helpers operating on API types.
+
+## Tooling
+
+Some providers script the first pass (terraform-provider-aws has an
+internal `tfsdk2fw` scaffolder). No public tool produces a safe migration
+end-to-end — treat any generated port as a draft to audit against this
+reference, especially the null/zero table above.


### PR DESCRIPTION
Adds a `provider-framework-migration` skill covering SDKv2 → Plugin Framework migration, as requested in #43 (and discussed in #14, where maintainers asked for Framework-first guidance and a way to keep SDKv2 content out of new-provider contexts — a dedicated migration skill keeps that concern separated).

**What it teaches**

- **Triage first**: don't migrate complex or heavily-used resources without a driving need — behavioral differences between the SDKs surface as silent breaking changes (the standing policy in terraform-provider-aws); the `go.mod` heuristic for detecting a provider's current mode
- **Mux setup**: a complete `main.go` combining a Framework provider with an SDKv2 provider via `tf5to6server.UpgradeServer` + `tf6muxserver` (with the protocol-5 alternative noted), plus the mux constraints that bite in practice (identical provider schemas, one owner per resource, Registry `protocol_versions` manifest)
- **Per-resource workflow**: baseline acceptance tests *before* migrating; blocks stay Blocks (nested attributes change user-facing HCL syntax); keep the exact schema including `id`; null-vs-zero semantics preserved; move the registration in the same commit
- **Verification**: pre-existing tests pass unchanged, `ImportStateVerify`, and an empty-plan check against state written by the last released version
- `references/schema-mapping.md`: the full translation table — types, `ForceNew`→`RequiresReplace`, `ValidateFunc`→validators, `Default`→defaults package, `DiffSuppressFunc`/`StateFunc`/`CustomizeDiff` equivalents, `d.Get`/`GetOk`/`HasChange`/`SetId` data-access mappings, and a dedicated section on the null/zero trap with code pairs

Note: the mux example uses the correct two-step `tf5to6server.UpgradeServer` form (it returns `(server, error)` and cannot be placed directly in the provider slice).

Closes #43.

**Verification:** `scripts/validate-structure.sh` passes; SKILL.md 203 lines + reference 102 lines; registers the skill in `terraform/README.md`, `AGENTS.md`, `CHANGELOG.md` (expect trivial adjacent-line conflicts with #78/#83 in those three files).
