### PR TITLE
update readme to note npx skill installation support for IBM Bob

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A collection of Agent skills and Claude Code plugins for HashiCorp products.
 
 ### Individual Skills
 
-Install Agent Skills in GitHub Copilot, Claude Code, Opencode, Cursor, and more:
+Install Agent Skills in GitHub Copilot, Claude Code, Opencode, Cursor, IBM Bob, and more:
 
 ```bash
 # List all skills


### PR DESCRIPTION
Updates readme to explicitly note that npx skill installation supports IBM Bob. 