### PR TITLE
chore: prepare v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the HashiCorp Agent Skills.
 
-## Unreleased
+## 1.0.0 - 2026-08-04
 
 ### Added
 - `terraform-search-import` skill for discovering existing resources with Terraform Search and bulk import


### PR DESCRIPTION
## Summary

- promote the existing unreleased changelog entries to `1.0.0`
- record the release date as 2026-08-04

## Impact

This documentation-only change prepares the repository for its first GitHub release. It does not change Skill, plugin, marketplace, or runtime behavior.

## Validation

- `git diff --check`
