### PR TITLE
Update terraform-policy skill for tfpolicy 0.1.x and 0.2.0+ compatibility

### DIFF
--- a/plugins/terraform/skills/refactor-module/SKILL.md
+++ b/plugins/terraform/skills/refactor-module/SKILL.md
@@ -546,8 +546,8 @@ module "vpc" {
 - [ ] No plan differences after refactoring
 
 ## Related Skills
-- [Terraform code generation](https://raw.githubusercontent.com/hashicorp/agent-skills/refs/heads/main/terraform/code-generation/skills/terraform-style-guide/SKILL.md) - Style guide for the new Terraform Module
-- [Azure Verified Modules](https://raw.githubusercontent.com/hashicorp/agent-skills/refs/heads/main/terraform/code-generation/skills/azure-verified-modules/SKILL.md) - Recommended module specifications for Azure
+- [Terraform code generation](https://raw.githubusercontent.com/hashicorp/agent-skills/refs/heads/main/plugins/terraform/skills/terraform-style-guide/SKILL.md) - Style guide for the new Terraform Module
+- [Azure Verified Modules](https://raw.githubusercontent.com/hashicorp/agent-skills/refs/heads/main/plugins/terraform/skills/azure-verified-modules/SKILL.md) - Recommended module specifications for Azure
 
 ## Resources
 - [Terraform Module Development](https://developer.hashicorp.com/terraform/language/modules/develop)

--- a/plugins/terraform/skills/terraform-policy/README.md
+++ b/plugins/terraform/skills/terraform-policy/README.md
@@ -32,6 +32,16 @@ terraform-policy/
 
 [`references/verified-syntax.md`](references/verified-syntax.md) is the single source of truth for verified Terraform Policy syntax, function names, and runtime limitations. All reference files link to it rather than duplicating facts — when reference content disagrees with this file, the reference wins.
 
+## Required provider declarations for `.policy.hcl`
+
+Authored `.policy.hcl` files must include a top-level `policy { required_providers { ... } }` block. `tfpolicy validate` uses these declarations for schema-aware validation, and validation fails if the block is omitted.
+
+For version ranges, validation is best effort: provider schemas at the lower and upper bounds of the declared range are evaluated. Wildcard targets such as `resource_policy "*"` are not schema-validated because they may match multiple resource types.
+
+See:
+- [`references/tfpolicy-author.md`](references/tfpolicy-author.md) for authoring guidance and examples
+- [`references/verified-syntax.md`](references/verified-syntax.md) for syntax and validation limitations
+
 ## Versioning
 
 Each reference is versioned independently via its `metadata.version` field.

--- a/plugins/terraform/skills/terraform-policy/SKILL.md
+++ b/plugins/terraform/skills/terraform-policy/SKILL.md
@@ -19,6 +19,11 @@ metadata:
 - Writing or debugging a `.policytest.hcl` test file
 - Migrating a Sentinel policy library to Terraform Policy
 
+Before giving authoring or testing instructions, check the installed `tfpolicy` CLI version and tailor guidance accordingly:
+- If the CLI is `0.1.x`, do **not** require `policy { required_providers { ... } }`; generate policies compatible with tfpolicy 0.1.x syntax and behavior.
+- If the CLI is `0.2.0` or newer, include a top-level `policy { required_providers { ... } }` block when authoring `.policy.hcl`. It is mandatory for `tfpolicy validate`; version-range validation is best effort, and wildcard targets such as `resource_policy "*"` are not schema-validated.
+- If the CLI version is unknown, ask the user to check it first or provide guidance that clearly distinguishes the `0.1.x` and `0.2.0+` paths.
+
 ## DO NOT USE FOR:
 
 - Writing `.tftest.hcl` files for Terraform modules — use `terraform-test`

--- a/plugins/terraform/skills/terraform-policy/references/tfpolicy-author.md
+++ b/plugins/terraform/skills/terraform-policy/references/tfpolicy-author.md
@@ -55,8 +55,38 @@ module_policy   "<module_pattern>" "<policy_name>" { }
 provider_policy "<provider_pattern>" "<policy_name>" { }
 ```
 
+### Required `policy.required_providers` Block
+
+Every `.policy.hcl` file must declare a top-level `policy { required_providers { ... } }` block. `tfpolicy validate` uses this block to resolve provider schemas for schema-aware validation, and validation fails when the block is omitted.
+
+```hcl
+policy {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0, < 7.0.0"
+    }
+  }
+}
+```
+
+**Rules and limitations:**
+- `required_providers` is mandatory for `.policy.hcl` validation.
+- Validation is **best effort** for version ranges. When a range is declared, validation evaluates provider schemas at the lower and upper bounds of the range.
+- Wildcard targets such as `resource_policy "*"` are not schema-validated because they may match multiple resource types.
+- `required_providers` declares provider source and version constraints for validation. This is distinct from `meta.version` in `provider_policy`, which exposes the resolved provider version during policy evaluation.
+
 ### Core Structure
 ```hcl
+policy {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0, < 7.0.0"
+    }
+  }
+}
+
 resource_policy "aws_ebs_volume" "encryption_check" {
   # Optional: pre-filter resources before evaluation
   filter = attrs.encrypted != null
@@ -643,6 +673,11 @@ Include the quality label, test success rate (if tests written), any limitations
 - Move complex predicates into `locals` for readability.
 
 ### Step 3 — Generate the policy
+- Start every `.policy.hcl` with a top-level `policy { required_providers { ... } }` block.
+- Use provider sources and version constraints that match the resource types referenced by the policy.
+- Run `tfpolicy validate` after authoring to confirm the policy parses and the referenced provider schemas can be resolved.
+- Remember that version-range validation is best effort: provider schemas at the lower and upper bounds are evaluated.
+- Wildcard targets such as `resource_policy "*"` are not schema-validated.
 - Wrap optional attributes in `core::try()`.
 - Keep each boolean expression on a single line.
 - Use multiple `enforce` blocks when you want independent diagnostics.
@@ -657,6 +692,15 @@ Include the quality label, test success rate (if tests written), any limitations
 User request: *"Ensure all S3 buckets have versioning enabled."*
 
 ```hcl
+policy {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0, < 7.0.0"
+    }
+  }
+}
+
 # Ensure S3 Bucket Versioning is Enabled
 #
 # Enforces that all AWS S3 buckets have versioning enabled to protect

--- a/plugins/terraform/skills/terraform-policy/references/tfpolicy-author.md
+++ b/plugins/terraform/skills/terraform-policy/references/tfpolicy-author.md
@@ -667,8 +667,7 @@ Include the quality label, test success rate (if tests written), any limitations
 - Start every `.policy.hcl` with a top-level `policy { required_providers { ... } }` block.
 - Use provider sources and version constraints that match the resource types referenced by the policy.
 - Run `tfpolicy validate` after authoring to confirm the policy parses and the referenced provider schemas can be resolved.
-- Remember that version-range validation is best effort: provider schemas at the lower and upper bounds are evaluated.
-- Wildcard targets such as `resource_policy "*"` are not schema-validated.
+- See [Required `policy.required_providers` Block](#required-policyrequired_providers-block) for validation limitations such as version-range best-effort checks and wildcard-target behavior.
 - Wrap optional attributes in `core::try()`.
 - Keep each boolean expression on a single line.
 - Use multiple `enforce` blocks when you want independent diagnostics.
@@ -682,16 +681,9 @@ Include the quality label, test success rate (if tests written), any limitations
 
 User request: *"Ensure all S3 buckets have versioning enabled."*
 
-```hcl
-policy {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 6.0.0, < 7.0.0"
-    }
-  }
-}
+Include the top-level `policy { required_providers { ... } }` block shown in [Core Structure](#core-structure).
 
+```hcl
 # Ensure S3 Bucket Versioning is Enabled
 #
 # Enforces that all AWS S3 buckets have versioning enabled to protect

--- a/plugins/terraform/skills/terraform-policy/references/tfpolicy-author.md
+++ b/plugins/terraform/skills/terraform-policy/references/tfpolicy-author.md
@@ -59,16 +59,7 @@ provider_policy "<provider_pattern>" "<policy_name>" { }
 
 Every `.policy.hcl` file must declare a top-level `policy { required_providers { ... } }` block. `tfpolicy validate` uses this block to resolve provider schemas for schema-aware validation, and validation fails when the block is omitted.
 
-```hcl
-policy {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 6.0.0, < 7.0.0"
-    }
-  }
-}
-```
+Use the same top-level `policy` scaffold shown in the Core Structure and Worked Example sections; only the provider source/version values should vary by policy.
 
 **Rules and limitations:**
 - `required_providers` is mandatory for `.policy.hcl` validation.

--- a/plugins/terraform/skills/terraform-policy/references/tfpolicy-author.md
+++ b/plugins/terraform/skills/terraform-policy/references/tfpolicy-author.md
@@ -71,10 +71,14 @@ Use the same top-level `policy` scaffold shown in the Core Structure and Worked 
 ```hcl
 policy {
   required_providers {
+    # Declare provider source and version constraints for validation.
+    # Use version ranges that cover the provider versions deployed in your infrastructure.
+    # Example with AWS provider (adjust based on your environment):
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0, < 7.0.0"
+      version = ">= 5.0.0, < 7.0.0"  # Covers AWS provider 5.x and 6.x
     }
+    # Add other providers as needed (azurerm, google, etc.)
   }
 }
 

--- a/plugins/terraform/skills/terraform-policy/references/tfpolicy-test.md
+++ b/plugins/terraform/skills/terraform-policy/references/tfpolicy-test.md
@@ -174,8 +174,18 @@ resource "aws_security_group_rule" "should_fail_port_90" {
    - Exit 0: All tests pass (including expected failures)
    - Exit 1: Unexpected failures or errors
 
+**Important schema-verification caveat:**
+- `tfpolicy validate --policies=...` performs provider schema acquisition and validates resource types against the providers declared in `policy.required_providers`.
+- `tfpolicy test --policies=... --tests=...` can still emit:
+  `Warning: Resource types not verified against provider schemas`
+  even when `validate` succeeded separately.
+- Interpret this as a **test-runner limitation/caveat**, not necessarily a policy failure. The test runner can execute mocks structurally while warning that resource-type verification was not enforced in that execution path.
+- Do **not** rely on `tfpolicy test` alone to catch misspelled or unknown resource types. Always run `tfpolicy validate` as a separate step before or alongside tests.
+- In current behavior, this warning may still produce a non-zero process exit code from `tfpolicy test`, even when all individual test cases show `pass`.
+
 **CI/CD Usage:**
 ```bash
+tfpolicy validate --policies=./policies
 tfpolicy test --policies=./policies --tests=./tests
 if [ $? -eq 0 ]; then echo "Passed"; else echo "Failed"; exit 1; fi
 ```

--- a/plugins/terraform/skills/terraform-policy/references/verified-syntax.md
+++ b/plugins/terraform/skills/terraform-policy/references/verified-syntax.md
@@ -123,6 +123,23 @@ filter = try(attrs.encrypted, false) == true  # Missing core:: prefix
   has_exception = core::try(core::regex("exception", core::try(attrs.description, "")), null) != null
   ```
 
+**`policy.required_providers` is mandatory for validation:** Every `.policy.hcl` file must declare a top-level `policy { required_providers { ... } }` block. `tfpolicy validate` uses this block to resolve provider schemas for schema-aware validation, and validation fails when the block is omitted.
+
+```hcl
+policy {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0, < 7.0.0"
+    }
+  }
+}
+```
+
+**Validation limitations:**
+- Validation is **best effort** for version ranges. When a range is declared, provider schemas at the lower and upper bounds of the range are evaluated.
+- Wildcard targets such as `resource_policy "*"` are not schema-validated because they may match multiple resource types.
+
 **Provider version constraint checks:** In `provider_policy`, `meta.version` is the **resolved provider version** (e.g. `"6.50.0"`), **not** the constraint string from `required_providers`. There is no tfpolicy surface that exposes the constraint string.
 
 > ⚠️ **`providers-require-version`-style Sentinel policies** that check `strings.has_prefix(p.version_constraint, ">")` inspect the version constraint format string, which tfpolicy does not expose. This check is **non-convertible**. The closest tfpolicy equivalent enforces that the **resolved provider version** is within an approved range:

--- a/plugins/terraform/skills/terraform-policy/references/verified-syntax.md
+++ b/plugins/terraform/skills/terraform-policy/references/verified-syntax.md
@@ -123,18 +123,7 @@ filter = try(attrs.encrypted, false) == true  # Missing core:: prefix
   has_exception = core::try(core::regex("exception", core::try(attrs.description, "")), null) != null
   ```
 
-**`policy.required_providers` is mandatory for validation:** Every `.policy.hcl` file must declare a top-level `policy { required_providers { ... } }` block. `tfpolicy validate` uses this block to resolve provider schemas for schema-aware validation, and validation fails when the block is omitted.
-
-```hcl
-policy {
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 6.0.0, < 7.0.0"
-    }
-  }
-}
-```
+**`policy.required_providers` is mandatory for validation:** Every `.policy.hcl` file must declare a top-level `policy { required_providers { ... } }` block. `tfpolicy validate` uses this block to resolve provider schemas for schema-aware validation, and validation fails when the block is omitted. See `tfpolicy-author.md` for concrete authoring examples.
 
 **Validation limitations:**
 - Validation is **best effort** for version ranges. When a range is declared, provider schemas at the lower and upper bounds of the range are evaluated.


### PR DESCRIPTION
## Summary
- document mandatory `policy.required_providers` usage for `.policy.hcl` when using `tfpolicy` 0.2.0+
- document best-effort validation behavior for version ranges
- document wildcard schema-validation limitations
- document `tfpolicy test` schema-verification caveat observed with `tfpolicy` 0.2.0
- add version-aware skill guidance so the skill branches between `tfpolicy` `0.1.x` and `0.2.0+`

## Changes
- updated `plugins/terraform/skills/terraform-policy/SKILL.md`
- updated `plugins/terraform/skills/terraform-policy/README.md`
- updated `plugins/terraform/skills/terraform-policy/references/tfpolicy-author.md`
- updated `plugins/terraform/skills/terraform-policy/references/tfpolicy-test.md`
- updated `plugins/terraform/skills/terraform-policy/references/verified-syntax.md`

## Notes
- `tfpolicy` `0.1.x` does not require `policy { required_providers { ... } }`
- `tfpolicy` `0.2.0+` requires top-level `policy { required_providers { ... } }` for `.policy.hcl` validation
- version-range validation is best effort
- wildcard targets such as `resource_policy "*"` are not schema-validated
- `tfpolicy test` may warn that resource types were not verified against provider schemas even when `tfpolicy validate` succeeds separately
- the skill now instructs the agent to check CLI version first and provide version-specific guidance

## Validation
```bash
./scripts/validate-structure.sh
git diff --check
```