### PR TITLE
chore: update github issue template autolabels and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/marketplace_installation.md
+++ b/.github/ISSUE_TEMPLATE/marketplace_installation.md
@@ -2,7 +2,7 @@
 name: Marketplace or Plugin Installation Issue
 about: Report a Claude Code or Codex plugin problem
 title: "installation: "
-labels: bug
+labels: plugin marketplace
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/new_skill_request.md
+++ b/.github/ISSUE_TEMPLATE/new_skill_request.md
@@ -2,7 +2,7 @@
 name: New Skill Request
 about: Propose a new Skill
 title: "skill proposal: "
-labels: enhancement
+labels: new skill
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/skill_bug.md
+++ b/.github/ISSUE_TEMPLATE/skill_bug.md
@@ -2,7 +2,7 @@
 name: Skill Bug or Incorrect Guidance
 about: Report non-sensitive incorrect or incomplete Skill behavior
 title: "skill bug: "
-labels: bug
+labels: skill bug
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/skill_update_request.md
+++ b/.github/ISSUE_TEMPLATE/skill_update_request.md
@@ -2,7 +2,7 @@
 name: Existing Skill Update Request
 about: Propose an update to an existing Skill
 title: "skill update: "
-labels: enhancement
+labels: skill update
 assignees: ""
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,35 +1,13 @@
-## What changed and why
+## Context
 
 ## Affected surfaces
 
-- Skills:
-- Product plugins:
-- Marketplace manifests:
-- Documentation or validation:
+- Skills: <!-- N/A if inapplicable. -->
+- Plugin Marketplaces: <!-- N/A if inapplicable. -->
+- Documentation: <!-- N/A if inapplicable. -->
+- Repository Metadata: <!-- N/A if inapplicable. -->
 
-## Source documentation
+## Ownership and Review
 
-<!-- Link authoritative HashiCorp product documentation or release notes. -->
-
-## Evaluation evidence
-
-<!-- Link the private redacted Waza summary or explain why evaluation is not applicable. -->
-
-## Supported-model impact
-
-## Security, privacy, credential, and operational considerations
-
-## Ownership and review
-
-- Ecosystem owner:
-- Applicable product-aligned owner or reviewers:
-
-## Verification
-
-- [ ] Structural validation passes.
-- [ ] Skill review is complete for changed Skills.
-- [ ] Private Waza evaluation is complete or has a recorded disposition.
-- [ ] CODEOWNERS review is requested.
-- [ ] Maintainer review is requested.
-- [ ] Claude Code and Codex marketplace checks pass when plugin definitions change.
-- [ ] Executable examples and links were checked where applicable.
+- [x] team-agent-skills-ecosystem
+<!-- [x] Relevant Skill-aligned reviewers if applicable. -->


### PR DESCRIPTION
## What changed and why

The GitHub Issue Templates now use newly added repo labels. The Pull Request Template has been updated to simplify and generalize it more.

## Affected surfaces

- Skills: N/A
- Product plugins: N/A
- Marketplace manifests: N/A
- Documentation or validation: Update GitHub Issue Templates and Pull Request Template
