### PR TITLE
docs: update supported openai model matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to HashiCorp Agent Skills.
 
 - Consolidated all 20 Skills under `plugins/<product>/skills/<skill-name>`.
 - Moved Waza evaluation assets to the private project context repository.
+- Narrowed the Supported Model Matrix to OpenAI GPT-5.6 Sol.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ agent-skills/
 - [SECURITY.md](SECURITY.md) for instructions on reporting security or data
   sensitivity issues related to this repository's Agent Skills.
 - [SUPPORT.md](SUPPORT.md) defines repository support boundaries.
+- [SUPPORTED_MODELS.md](SUPPORTED_MODELS.md) defines the current supported model matrix.
 - `CODEOWNERS` for canonical Skill ownership and review-routing source.
 
 ## License

--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -8,7 +8,20 @@ Approving authority: `@hashicorp/team-agent-skills-ecosystem`.
 | --- | --- | --- | --- | --- | --- |
 | OpenAI | GPT | Latest | OpenAI GPT-5.6 Sol | 2026-08-25 | `@hashicorp/team-agent-skills-ecosystem` |
 
+The normal support operating model includes `Latest` and `N-1`. A temporary
+Inference Availability Exception is active because AWS Bedrock does not expose
+GPT-5.5, so the current matrix intentionally has no `N-1` row. GPT-5.6 Terra is
+a sibling variant, not an `N-1` release, and no additional-current-variant
+support category is defined. When a newer approved OpenAI GPT release and
+GPT-5.6 Sol are both available through Bedrock, the newer release becomes
+`Latest` and GPT-5.6 Sol becomes `N-1`.
+
 Supported means maintainers intentionally design, evaluate, and maintain Skills
 against the listed baseline. It does not promise identical behavior across
 models or harnesses. A model outside this matrix is unsupported or unevaluated,
-not necessarily incompatible.
+not necessarily incompatible. Training-data cutoff metadata is not required for
+supported status.
+
+OpenAI is the Model Provider. Private Evaluation inference uses AWS Bedrock as
+the Inference Provider; that execution path does not change model-provider
+identity or add other Bedrock-hosted models to the support contract.

--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -1,20 +1,14 @@
 # Supported Models
 
-Effective date: 2026-07-23.
+Effective date: 2026-08-25.
 
 Approving authority: `@hashicorp/team-agent-skills-ecosystem`.
 
-| Provider | Model family | Support status | Model name | Effective date | Approving authority |
+| Model Provider | Model family | Support status | Model name | Effective date | Approving authority |
 | --- | --- | --- | --- | --- | --- |
-| OpenAI | GPT | Latest | OpenAI GPT-5.6 Terra | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
-| OpenAI | GPT | N-1 | OpenAI GPT-5.5 | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
-| Anthropic | Claude Opus | Latest | Anthropic Claude Opus 4.8 | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
-| Anthropic | Claude Opus | N-1 | Anthropic Claude Opus 4.7 | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
-| Anthropic | Claude Sonnet | Latest | Anthropic Claude Sonnet 4.6 | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
-| Anthropic | Claude Sonnet | N-1 | Anthropic Claude Sonnet 4.5 | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
+| OpenAI | GPT | Latest | OpenAI GPT-5.6 Sol | 2026-08-25 | `@hashicorp/team-agent-skills-ecosystem` |
 
 Supported means maintainers intentionally design, evaluate, and maintain Skills
 against the listed baseline. It does not promise identical behavior across
 models or harnesses. A model outside this matrix is unsupported or unevaluated,
-not necessarily incompatible. Training-data cutoff metadata is not required for
-supported status.
+not necessarily incompatible.


### PR DESCRIPTION
## What changed

This updates the public supported-model documentation to match the models we can currently evaluate and maintain:

- OpenAI GPT-5.6 Sol is now the only supported model.
- The normal Latest and N-1 operating model remains in place, but the N-1 row is temporarily omitted because GPT-5.5 is unavailable through AWS Bedrock.

The documentation also clarifies that OpenAI is the Model Provider while AWS Bedrock is the Inference Provider used for private Evaluations.

## Affected surfaces

- Skills: no Skill source changes; the supported baseline applies to all 20 Skills
- Plugin Marketplaces: N/A
- Documentation: `README.md`, `SUPPORTED_MODELS.md`, and `CHANGELOG.md`
- Repository Metadata: N/A

## Validation

- `./scripts/validate-structure.sh`
- `python3 scripts/check-links.py --local-only`
- `git diff --check`

## Ownership and review

- [x] team-agent-skills-ecosystem
