### PR TITLE
docs: update supported model matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to HashiCorp Agent Skills.
 
 - Consolidated all 20 Skills under `plugins/<product>/skills/<skill-name>`.
 - Moved Waza evaluation assets to the private project context repository.
+- Updated the Supported Model Matrix to the Bedrock-evaluable Claude Opus,
+  Claude Sonnet, and OpenAI GPT baselines.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ agent-skills/
   sensitivity issues related to this repository's Agent Skills.
 - [SUPPORT.md](SUPPORT.md) defines repository support boundaries.
 - [SUPPORTED_MODELS.md](SUPPORTED_MODELS.md) defines the current Anthropic and
-  OpenAI supported model matrix. Private compatibility evaluations use AWS
-  Bedrock as their sole inference provider.
+  OpenAI supported model matrix.
 - `CODEOWNERS` for canonical Skill ownership and review-routing source.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ agent-skills/
 - [SECURITY.md](SECURITY.md) for instructions on reporting security or data
   sensitivity issues related to this repository's Agent Skills.
 - [SUPPORT.md](SUPPORT.md) defines repository support boundaries.
+- [SUPPORTED_MODELS.md](SUPPORTED_MODELS.md) defines the current Anthropic and
+  OpenAI supported model matrix. Private compatibility evaluations use AWS
+  Bedrock as their sole inference provider.
 - `CODEOWNERS` for canonical Skill ownership and review-routing source.
 
 ## License

--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -14,18 +14,10 @@ Approving authority: `@hashicorp/team-agent-skills-ecosystem`.
 
 The normal support operating model includes `Latest` and `N-1` for each
 model family. A temporary Claude Sonnet Inference Availability Exception is
-active because the AWS Bedrock Mantle service available to the Evaluation
-account exposes no earlier Sonnet release. The missing Sonnet `N-1` row is a
-governed exception, not an Unsupported Gap; it does not create another support
-category or permit a substitute model.
+active for the Claude Sonnet N-1 model version.
 
 Supported means maintainers intentionally design, evaluate, and maintain Skills
 against the listed baseline. It does not promise identical behavior across
 models or harnesses. A model outside this matrix is unsupported or unevaluated,
 not necessarily incompatible. Training-data cutoff metadata is not required for
 supported status.
-
-Anthropic and OpenAI are the Model Providers. Private Evaluation inference uses
-AWS Bedrock as the sole Inference Provider. That execution path does not change
-model-provider identity or add other Bedrock-hosted models to the support
-contract.

--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -1,20 +1,31 @@
 # Supported Models
 
-Effective date: 2026-07-23.
+Effective date: 2026-08-31.
 
 Approving authority: `@hashicorp/team-agent-skills-ecosystem`.
 
-| Provider | Model family | Support status | Model name | Effective date | Approving authority |
+| Model Provider | Model family | Support status | Model ID | Effective date | Approving authority |
 | --- | --- | --- | --- | --- | --- |
-| OpenAI | GPT | Latest | OpenAI GPT-5.6 Terra | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
-| OpenAI | GPT | N-1 | OpenAI GPT-5.5 | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
-| Anthropic | Claude Opus | Latest | Anthropic Claude Opus 4.8 | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
-| Anthropic | Claude Opus | N-1 | Anthropic Claude Opus 4.7 | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
-| Anthropic | Claude Sonnet | Latest | Anthropic Claude Sonnet 4.6 | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
-| Anthropic | Claude Sonnet | N-1 | Anthropic Claude Sonnet 4.5 | 2026-07-23 | `@hashicorp/team-agent-skills-ecosystem` |
+| Anthropic | Claude Opus | Latest | `anthropic.claude-opus-5` | 2026-08-31 | `@hashicorp/team-agent-skills-ecosystem` |
+| Anthropic | Claude Opus | N-1 | `anthropic.claude-opus-4-8` | 2026-08-31 | `@hashicorp/team-agent-skills-ecosystem` |
+| Anthropic | Claude Sonnet | Latest | `anthropic.claude-sonnet-5` | 2026-08-31 | `@hashicorp/team-agent-skills-ecosystem` |
+| OpenAI | GPT | Latest | `openai.gpt-5.6-sol` | 2026-08-31 | `@hashicorp/team-agent-skills-ecosystem` |
+| OpenAI | GPT | N-1 | `openai.gpt-5.5` | 2026-08-31 | `@hashicorp/team-agent-skills-ecosystem` |
+
+The normal support operating model includes `Latest` and `N-1` for each
+model family. A temporary Claude Sonnet Inference Availability Exception is
+active because the AWS Bedrock Mantle service available to the Evaluation
+account exposes no earlier Sonnet release. The missing Sonnet `N-1` row is a
+governed exception, not an Unsupported Gap; it does not create another support
+category or permit a substitute model.
 
 Supported means maintainers intentionally design, evaluate, and maintain Skills
 against the listed baseline. It does not promise identical behavior across
 models or harnesses. A model outside this matrix is unsupported or unevaluated,
 not necessarily incompatible. Training-data cutoff metadata is not required for
 supported status.
+
+Anthropic and OpenAI are the Model Providers. Private Evaluation inference uses
+AWS Bedrock as the sole Inference Provider. That execution path does not change
+model-provider identity or add other Bedrock-hosted models to the support
+contract.


### PR DESCRIPTION
## Context

This PR replaces #99. It updates the "Supported Models" matrix to include all IBM-available "latest" and N-1 model versions of Anthropic Opus & Sonnet, as well as OpenAI GPT.

## Affected surfaces

- Skills: N/A
- Plugin Marketplaces: N/A
- Documentation: `CHANGELOG.md`, `README.md`, and `SUPPORTED_MODELS.md`
- Repository Metadata: N/A

Validated with the repository structure and Markdown link checks. The public and project-context copies of `SUPPORTED_MODELS.md` are byte-for-byte identical.

## Ownership and Review

- [x] team-agent-skills-ecosystem
